### PR TITLE
OEUI-81: Update the table display format for active and past orders

### DIFF
--- a/app/js/components/orderEntry/ActiveOrders.jsx
+++ b/app/js/components/orderEntry/ActiveOrders.jsx
@@ -80,12 +80,7 @@ export class ActiveOrders extends React.Component {
           <td>
             {format(dateActivated, 'MM-DD-YYYY HH:mm')} {autoExpireDate && (`- ${format(autoExpireDate, 'MM-DD-YYYY HH:mm')}`)}
           </td>
-          <td>
-            Active
-          </td>
-
           {details}
-
           <td className="text-center action-padding">
             <a href="#"> <i className="icon-edit" title="Edit" /> </a>
             <a href="#"> <i className="icon-remove" title="Delete" /> </a>
@@ -117,7 +112,6 @@ export class ActiveOrders extends React.Component {
           <thead>
             <tr>
               <th className="w-145-px">Date</th>
-              <th className="w-120-px">Status</th>
               <th>Details</th>
               <th className="w-81-px">Actions</th>
             </tr>

--- a/app/js/components/orderEntry/PastOrder.jsx
+++ b/app/js/components/orderEntry/PastOrder.jsx
@@ -8,16 +8,6 @@ export const PastOrder = (props) => {
     quantityUnits, autoExpireDate, quantity,
   } = props;
 
-  const getStatus = () => {
-    if (action === "NEW" && autoExpireDate !== null) {
-      return 'Completed';
-    } else if (autoExpireDate !== null && action === "REVISE") {
-      return 'Revised';
-    } else if (autoExpireDate === null) {
-      return 'Discontinued';
-    }
-  };
-
   let details;
   if (dosingType === 'org.openmrs.SimpleDosingInstructions') {
     details = (
@@ -48,12 +38,8 @@ export const PastOrder = (props) => {
       <td>
         {format(auditInfo.dateCreated, 'DD-MM-YYYY HH:MM')} {autoExpireDate && `- ${format(autoExpireDate, 'DD-MM-YYYY HH:MM')}`}
       </td>
-      <td>{action ? `${getStatus()}` : ""}</td>
       <td>
         {details}
-      </td>
-      <td className="text-center pl-39-px">
-        <a href="#"> <i className="icon-ban-circle" title="Delete" /> </a>
       </td>
     </tr>
   );

--- a/app/js/components/orderEntry/PastOrders.jsx
+++ b/app/js/components/orderEntry/PastOrders.jsx
@@ -36,9 +36,7 @@ export class PastOrders extends React.Component {
             <thead>
               <tr>
                 <th className="w-145-px">Date</th>
-                <th className="w-120-px">Status</th>
                 <th>Details</th>
-                <th className="w-81-px">Actions</th>
               </tr>
             </thead>
             <tbody>
@@ -46,7 +44,7 @@ export class PastOrders extends React.Component {
                 <PastOrder key={pastOrder.uuid} {...pastOrder} />)}
             </tbody>
           </table>
-          : <p>No Past Orders</p>}
+          : <p id="no_past_orders">No Past Orders</p>}
         <div />
       </div>
     );

--- a/tests/components/orderentry/PastOrders.test.jsx
+++ b/tests/components/orderentry/PastOrders.test.jsx
@@ -37,8 +37,4 @@ describe('Test for Past orders', () => {
     const wrapper = mount(<PastOrders {...props}/>  );
     expect(wrapper.find('table')).toHaveLength(1);
   });
-  it('should render no past orders', () => {
-    const wrapper = mount(<PastOrders {...props} />  );
-    expect(wrapper.find('a')).toHaveLength(1);
-  });
 });


### PR DESCRIPTION
## JIRA TICKET NAME:
[OEUI-81: Update the table display format for active and past orders](https://issues.openmrs.org/browse/OEUI-81)
### SUMMARY:
This task basically meant to implement the feedback got from the community about the fields that should appear in Active and Past order tables