### PR TITLE
OEUI-93: Check for the existance of the order.encounterRole setting (Bug Fix)

### DIFF
--- a/app/js/actions/settingEncounterRole.js
+++ b/app/js/actions/settingEncounterRole.js
@@ -17,23 +17,23 @@ export const settingEncounterRoleFailure = error => ({
   error,
 });
 
+const NotFoundException = message => ({
+  message,
+  response: 'Not Found',
+});
+
 export const getSettingEncounterRole = () => (dispatch) => {
   dispatch(loading('SETTING_ENCOUNTER_ROLE', true));
   return axiosInstance.get(`systemsetting?v=custom:(value)&q=order.encounterRole`)
     .then((response) => {
-      if (response.status !== 200) {
-        throw Error(response.statusText);
-      }
-      dispatch(loading('SETTING_ENCOUNTER_ROLE', false));
-      return response;
+      if (response.data.results.length > 0) {
+        dispatch(loading('SETTING_ENCOUNTER_ROLE', false));
+        dispatch(settingEncounterRoleSuccess(response.data.results[0].value));
+      } else throw NotFoundException('Property not found');
     })
-    .then(response => dispatch(settingEncounterRoleSuccess(response.data.results[0].value)))
     .catch((error) => {
       dispatch(loading('SETTING_ENCOUNTER_ROLE', false));
-      if (error.response) {
-        dispatch(settingEncounterRoleFailure(error));
-      } else {
-        dispatch(networkError('Network error occurred'));
-      }
+      if (!error.response) dispatch(networkError('Network error occurred'));
+      else dispatch(settingEncounterRoleFailure(error));
     });
 };

--- a/app/js/reducers/settingEncounterRoleReducer.js
+++ b/app/js/reducers/settingEncounterRoleReducer.js
@@ -3,6 +3,7 @@ import {
   SETTING_ENCOUNTER_ROLE_SUCCESS,
   SETTING_ENCOUNTER_ROLE_FAILURE,
   SETTING_ENCOUNTER_ROLE_LOADING,
+  NETWORK_ERROR,
 } from '../../../app/js/actions/actionTypes';
 
 const settingEncounterRoleReducer = (
@@ -15,6 +16,8 @@ const settingEncounterRoleReducer = (
     case SETTING_ENCOUNTER_ROLE_LOADING:
       return { ...state, isLoading: action.status };
     case SETTING_ENCOUNTER_ROLE_FAILURE:
+      return { ...state, roleError: action.error };
+    case NETWORK_ERROR:
       return { ...state, roleError: action.error };
     default:
       return state;

--- a/tests/actions/settingEncounterRole.test.js
+++ b/tests/actions/settingEncounterRole.test.js
@@ -34,14 +34,12 @@ describe ('Get the encounterRole configuration actions', () => {
             moxios.install();
         });
 
-        it ('should dispatch `SETTING_ENCOUNTER_ROLE_SUCCESS` after sucessful fetching', () => {
+        it ('should dispatch `SETTING_ENCOUNTER_ROLE_SUCCESS` after successful fetching', () => {
             moxios.wait(() => {
                 const request = moxios.requests.mostRecent();
                 request.respondWith({
                     status: 200,
-                    response: {
-                        results: 'clinician'
-                    },
+                    response: { results: ['clinician']},
                 });
             });
 
@@ -60,14 +58,12 @@ describe ('Get the encounterRole configuration actions', () => {
             });
         });
 
-        it ('should dispatch `SETTING_ENCOUNTER_ROLE_SUCCESS` after an error', () => {
+        it ('should dispatch `SETTING_ENCOUNTER_ROLE_FAILURE` after an error', () => {
             moxios.wait(() => {
                 const request = moxios.requests.mostRecent();
                 request.respondWith({
                     status: 401,
-                    response: {
-                        error: 'Unauthorised'
-                    },
+                    error: 'Unauthorised'
                 });
             });
 


### PR DESCRIPTION
### JIRA TICKET NAME 
[OEUI-93: Check for order.encounterRole setting](https://issues.openmrs.org/browse/OEUI-93)

## Summary:
- Actions and Reducers to check if the setting for order.encounterRole exists.
- Conditional rendering of SearchAndAddOrder depending on the existence of the setting.
- Tests for the actions, reducers, and component.