### PR TITLE
OEUI-100: Checking the existence of encounter role

### DIFF
--- a/__mocks__/mockData.js
+++ b/__mocks__/mockData.js
@@ -53,14 +53,12 @@ export default {
     results: [],
   },
   encounterRole: {
-    data: {
-      results: [
-        {
-          uuid: '',
-          display: '',
-        },
-      ],
-    },
+    results: [
+      {
+        uuid: '',
+        display: 'Order Signer',
+      },
+    ],
   },
   defaultpatientActiveOrder: {
     activeOrders: [],

--- a/app/js/actions/encounterRole.js
+++ b/app/js/actions/encounterRole.js
@@ -2,31 +2,29 @@ import axios from 'axios';
 import {
   FETCH_ENCOUNTER_ROLE_LOADING,
   FETCH_ENCOUNTER_ROLE_SUCCESS,
-  FETCH_ENCOUNTER_ROLE_FAILURE,
 } from './actionTypes';
 import networkError from './networkError';
 import loading from './loading';
 import axiosInstance from '../config';
+import { settingEncounterRoleFailure } from './settingEncounterRole';
 
 export const fetchEncounterRoleSuccess = encounterRole => ({
   type: FETCH_ENCOUNTER_ROLE_SUCCESS,
   encounterRole,
 });
-export const fetchEncounterRoleFailure = error => ({
-  type: FETCH_ENCOUNTER_ROLE_FAILURE,
-  error,
-});
+
 export const fetchEncounterRole = value => (dispatch) => {
   dispatch(loading('FETCH_ENCOUNTER_ROLE', true));
   return axiosInstance.get(`encounterrole?q=${value}`)
-    .then((response) => {
-      dispatch(fetchEncounterRoleSuccess(response.data.results));
-    }).catch((error) => {
-      dispatch(loading('FETCH_ENCOUNTER_ROLE', false));
-      if (error.response) {
-        dispatch(fetchEncounterRoleFailure(error));
-      } else {
-        dispatch(networkError('Network error occurred'));
+    .then(({ data: { results } }) => {
+      if (results.length === 0) {
+        throw Error("incomplete config");
       }
+
+      dispatch(fetchEncounterRoleSuccess(results[0]));
+      dispatch(loading('FETCH_ENCOUNTER_ROLE', false));
+    }).catch((error) => {
+      dispatch(settingEncounterRoleFailure(error.message));
+      dispatch(loading('FETCH_ENCOUNTER_ROLE', false));
     });
 };

--- a/app/js/actions/settingEncounterRole.js
+++ b/app/js/actions/settingEncounterRole.js
@@ -6,6 +6,7 @@ import {
 import axiosInstance from '../config';
 import loading from './loading';
 import networkError from './networkError';
+import { fetchEncounterRole } from './encounterRole';
 
 export const settingEncounterRoleSuccess = configuration => ({
   type: SETTING_ENCOUNTER_ROLE_SUCCESS,
@@ -27,13 +28,15 @@ export const getSettingEncounterRole = () => (dispatch) => {
   return axiosInstance.get(`systemsetting?v=custom:(value)&q=order.encounterRole`)
     .then((response) => {
       if (response.data.results.length > 0) {
+        const { value } = response.data.results[0];
+        dispatch(settingEncounterRoleSuccess(value));
+        dispatch(fetchEncounterRole(value));
         dispatch(loading('SETTING_ENCOUNTER_ROLE', false));
-        dispatch(settingEncounterRoleSuccess(response.data.results[0].value));
       } else throw NotFoundException('Property not found');
     })
     .catch((error) => {
-      dispatch(loading('SETTING_ENCOUNTER_ROLE', false));
       if (!error.response) dispatch(networkError('Network error occurred'));
       else dispatch(settingEncounterRoleFailure(error));
+      dispatch(loading('SETTING_ENCOUNTER_ROLE', false));
     });
 };

--- a/app/js/components/orderEntry/OrderEntryPage.jsx
+++ b/app/js/components/orderEntry/OrderEntryPage.jsx
@@ -53,16 +53,26 @@ export class OrderEntryPage extends React.Component {
       );
     }
 
-    if (settingEncounterRole.length === 0 && roleError) {
+    if (settingEncounterRole.length === 0 || roleError) {
       return (
         <div className="error-notice">
           <p>
-            Setting for <strong>order.encounterRole</strong> does not exist.
-            Please contact your administrator to create one for you.
+            Configuration for <strong>order.encounterRole</strong> {roleError === 'incomplete config' ? 'is incomplete' : 'does not exist'}.
+            Please contact your administrator for more information.
           </p>
           <p>
-            As an Administrator, if you have already configured this setting, please check
-            if its name corresponds to <strong>order.encounterRole</strong>
+            As an Administrator,&nbsp;
+            {
+              roleError === 'incomplete config' ?
+                <span>
+                  please ensure that you have created a valid <strong>encounter role</strong>.
+                </span> :
+                <span>
+                  ensure that you have created a setting called<strong>order.encounterRole</strong>
+                  &nbsp;
+                  with a value corresponding to the encounter type above.
+                </span>
+            }
           </p>
         </div>
       );

--- a/app/js/reducers/encounterRoleReducer.js
+++ b/app/js/reducers/encounterRoleReducer.js
@@ -17,11 +17,6 @@ const encounterRole = (state = initialState.encounterRoleReducer, action) => {
         ...state,
         encounterRole: action.encounterRole,
       };
-    case FETCH_ENCOUNTER_ROLE_FAILURE:
-      return {
-        ...state,
-        error: action.error,
-      };
     default:
       return state;
   }

--- a/app/js/reducers/settingEncounterRoleReducer.js
+++ b/app/js/reducers/settingEncounterRoleReducer.js
@@ -17,8 +17,6 @@ const settingEncounterRoleReducer = (
       return { ...state, isLoading: action.status };
     case SETTING_ENCOUNTER_ROLE_FAILURE:
       return { ...state, roleError: action.error };
-    case NETWORK_ERROR:
-      return { ...state, roleError: action.error };
     default:
       return state;
   }

--- a/tests/actions/encounterRole.test.js
+++ b/tests/actions/encounterRole.test.js
@@ -1,15 +1,15 @@
 import {
     fetchEncounterRoleSuccess,
-    fetchEncounterRoleFailure,
     fetchEncounterRole,
 } from '../../app/js/actions/encounterRole';
 import {
     FETCH_ENCOUNTER_ROLE_LOADING,
     FETCH_ENCOUNTER_ROLE_SUCCESS,
-    FETCH_ENCOUNTER_ROLE_FAILURE,
+    SETTING_ENCOUNTER_ROLE_FAILURE,
   } from '../../app/js/actions/actionTypes';
 
 const encounterRole = mockData.encounterRole;
+const value = "Order Signer";
 
 describe('encounterRole get action creators', () => {
     it('should create FETCH_ENCOUNTER_ROLE_SUCEESS action', () => {
@@ -19,23 +19,16 @@ describe('encounterRole get action creators', () => {
         const actionType = store.getActions().map(action => action.type);
         expect(actionType).toEqual(expectedAction);
     });
-    it('should create FETCH_ENCOUNTER_ROLE_FAILURE action', () => {
-        const store = mockStore({});
-        const expectedAction = [ FETCH_ENCOUNTER_ROLE_FAILURE ]
-        store.dispatch(fetchEncounterRoleFailure())
-        const actionType = store.getActions().map(action => action.type);
-        expect(actionType).toEqual(expectedAction);
-    });
 });
 describe('encounterRole get thunk', () => {
-    const value = "Order Signer";
     beforeEach( () => {
         moxios.install();
     });
     afterEach( () => {
         moxios.uninstall();
     });
-    it('should dispatch FETCH_ENCOUNTER_ROLE_SUCEESS on success', async (done) => {
+
+    it('should dispatch FETCH_ENCOUNTER_ROLE_SUCCESS on success with results', async (done) => {
         const store = mockStore({});
         moxios.stubRequest(`${apiBaseUrl}/encounterrole?q=${value}`, {
             status: 200,
@@ -43,15 +36,38 @@ describe('encounterRole get thunk', () => {
         });
         const expectedActions = [
             FETCH_ENCOUNTER_ROLE_LOADING,
-            FETCH_ENCOUNTER_ROLE_SUCCESS
+            FETCH_ENCOUNTER_ROLE_SUCCESS,
+            FETCH_ENCOUNTER_ROLE_LOADING,
         ]
         await store.dispatch(fetchEncounterRole(value))
-        .then ( () => {
+        .then(() => {
             const actionType = store.getActions().map(action => action.type);
             expect(actionType).toEqual(expectedActions);
         });
         done();
     });
+
+    it('should dispatch FETCH_ENCOUNTER_ROLE_SUCCESS on success with empty result', async (done) => {
+        const store = mockStore({});
+        moxios.stubRequest(`${apiBaseUrl}/encounterrole?q=${value}`, {
+            status: 200,
+            response: {...encounterRole, ...encounterRole.data,
+                results: []
+            }
+        });
+        const expectedActions = [
+            FETCH_ENCOUNTER_ROLE_LOADING,
+            SETTING_ENCOUNTER_ROLE_FAILURE,
+            FETCH_ENCOUNTER_ROLE_LOADING,
+        ]
+        await store.dispatch(fetchEncounterRole(value))
+        .then(() => {
+            const actionType = store.getActions().map(action => action.type);
+            expect(actionType).toEqual(expectedActions);
+        });
+        done();
+    });
+
     it('should dispatch FETCH_ENCOUNTER_ROLE_FAILURE on fail', async (done) => {
         const store = mockStore({});
         moxios.stubRequest(`${apiBaseUrl}/encounterrole?q=${value}`, {
@@ -62,8 +78,8 @@ describe('encounterRole get thunk', () => {
         });
         const expectedActions = [
             FETCH_ENCOUNTER_ROLE_LOADING,
+            SETTING_ENCOUNTER_ROLE_FAILURE,
             FETCH_ENCOUNTER_ROLE_LOADING,
-            FETCH_ENCOUNTER_ROLE_FAILURE
         ]
         await store.dispatch(fetchEncounterRole(value))
         .then ( () => {

--- a/tests/actions/settingEncounterRole.test.js
+++ b/tests/actions/settingEncounterRole.test.js
@@ -9,7 +9,11 @@ import {
     SETTING_ENCOUNTER_ROLE_LOADING,
 } from '../../app/js/actions/actionTypes';
 
-describe ('Get the encounterRole configuration actions', () => {
+jest.mock('../../app/js/actions/encounterRole', () => ({
+    fetchEncounterRole: (value) => jest.fn()
+}));
+
+describe('Get the encounterRole configuration actions', () => {
     it('should create an action to store fetched configuration', () => {
         const configuration = 'order entry';
         const expectedAction = {
@@ -28,28 +32,28 @@ describe ('Get the encounterRole configuration actions', () => {
         expect(settingEncounterRoleFailure(error)).toEqual(expectedAction);
     });
 
-    describe ('Get setting for encounterRole API call', () => {
+    describe('Get setting for encounterRole API call', () => {
 
         beforeEach(() => {
             moxios.install();
         });
 
-        it ('should dispatch `SETTING_ENCOUNTER_ROLE_SUCCESS` after successful fetching', () => {
+        it('should dispatch `SETTING_ENCOUNTER_ROLE_SUCCESS` with results', () => {
             moxios.wait(() => {
                 const request = moxios.requests.mostRecent();
                 request.respondWith({
                     status: 200,
-                    response: { results: ['clinician']},
+                    response: { results: ['clinician'] },
                 });
             });
 
             const expectedActions = [
                 SETTING_ENCOUNTER_ROLE_LOADING,
+                SETTING_ENCOUNTER_ROLE_SUCCESS,
                 SETTING_ENCOUNTER_ROLE_LOADING,
-                SETTING_ENCOUNTER_ROLE_SUCCESS
             ];
-            
-            const store = mockStore({ setting: {}});
+
+            const store = mockStore({ setting: {} });
 
             return store.dispatch(getSettingEncounterRole()).then(() => {
                 const dispatchedActions = store.getActions();
@@ -58,7 +62,31 @@ describe ('Get the encounterRole configuration actions', () => {
             });
         });
 
-        it ('should dispatch `SETTING_ENCOUNTER_ROLE_FAILURE` after an error', () => {
+        it('should dispatch `SETTING_ENCOUNTER_ROLE_FAILURE` if empty results returned', () => {
+            moxios.wait(() => {
+                const request = moxios.requests.mostRecent();
+                request.respondWith({
+                    status: 200,
+                    response: { results: [] },
+                });
+            });
+
+            const expectedActions = [
+                SETTING_ENCOUNTER_ROLE_LOADING,
+                SETTING_ENCOUNTER_ROLE_FAILURE,
+                SETTING_ENCOUNTER_ROLE_LOADING,
+            ];
+
+            const store = mockStore({ setting: {} });
+
+            return store.dispatch(getSettingEncounterRole()).then(() => {
+                const dispatchedActions = store.getActions();
+                const dispatchedActionTypes = dispatchedActions.map(action => action.type);
+                expect(dispatchedActionTypes).toEqual(expectedActions);
+            });
+        });
+
+        it('should dispatch `SETTING_ENCOUNTER_ROLE_FAILURE` after an error', () => {
             moxios.wait(() => {
                 const request = moxios.requests.mostRecent();
                 request.respondWith({
@@ -69,11 +97,11 @@ describe ('Get the encounterRole configuration actions', () => {
 
             const expectedActions = [
                 SETTING_ENCOUNTER_ROLE_LOADING,
+                SETTING_ENCOUNTER_ROLE_FAILURE,
                 SETTING_ENCOUNTER_ROLE_LOADING,
-                SETTING_ENCOUNTER_ROLE_FAILURE
             ];
-            
-            const store = mockStore({ setting: {}});
+
+            const store = mockStore({ setting: {} });
 
             return store.dispatch(getSettingEncounterRole()).then(() => {
                 const dispatchedActions = store.getActions();

--- a/tests/components/orderentry/addForm/DraftDataTable.test.jsx
+++ b/tests/components/orderentry/addForm/DraftDataTable.test.jsx
@@ -20,7 +20,7 @@ const props = {
     fetchEncounterRole: jest.fn(),
     handleDiscardOneOrder: jest.fn(),
     handleDiscardAllOrders: jest.fn(),
-    encounterRole: encounterRole.data.results,
+    encounterRole: encounterRole.results,
     allConfigurations,
     sessionReducer,
     encounterType,

--- a/tests/reducers/encounterRoleReducer.test.js
+++ b/tests/reducers/encounterRoleReducer.test.js
@@ -11,8 +11,7 @@ const encounterRole = mockData.encounterRole;
 describe('encounterRole reducer for get actions', () => {
     const initialState = {
         isLoading: false,
-        encounterRole: {},
-        error: null,
+        encounterRole: [],
       };
     it('should return loading as true', () => {
         const initialState = {};
@@ -34,7 +33,6 @@ describe('encounterRole reducer for get actions', () => {
         const expected = {
             isLoading: false,
             encounterRole: encounterRole,
-            error: null,
         };
         const newSate = encounterRoleReducer(initialState, action);
         expect(newSate).toEqual(expected);
@@ -46,8 +44,7 @@ describe('encounterRole reducer for get actions', () => {
         }
         const expected = {
             isLoading: false,
-            encounterRole: {},
-            error: "User not logged in"
+            encounterRole: [],
         };
         const newSate = encounterRoleReducer(initialState, action);
         expect(newSate).toEqual(expected);

--- a/tests/reducers/settingEncounterRoleReducer.test.js
+++ b/tests/reducers/settingEncounterRoleReducer.test.js
@@ -1,9 +1,10 @@
 import deepFreeze from 'deep-freeze';
 import {
     settingEncounterRoleSuccess,
-    settingEncounterRoleLoading,
     settingEncounterRoleFailure,
 } from '../../app/js/actions/settingEncounterRole';
+
+import loading from '../../app/js/actions/loading'
 import settingEncounterRoleReducer from '../../app/js/reducers/settingEncounterRoleReducer';
 
 
@@ -23,6 +24,20 @@ describe('Setting Encounter Tole reducer', () => {
         expect(initialState).toEqual(expectedState);
     });
 
+    it('should handle `SETTING_ENCOUNTER_ROLE_LOADING`', () => {
+        const configuration = 'clinician';
+        const expectedState = {
+            settingEncounterRole: '',
+            isLoading: true,
+            roleError: ''
+        };
+        const actualState = settingEncounterRoleReducer(
+            initialState,
+            loading('SETTING_ENCOUNTER_ROLE', true)
+        );
+        expect(actualState).toEqual(expectedState);
+    });
+
     it('should handle `SETTING_ENCOUNTER_ROLE_SUCCESS`', () => {
         const configuration = 'clinician';
         const expectedState = {
@@ -36,7 +51,7 @@ describe('Setting Encounter Tole reducer', () => {
         );
         expect(actualState).toEqual(expectedState);
     });
-    
+
     it('should handle `SETTING_ENCOUNTER_ROLE_FAILURE`', () => {
         const expectedState = {
             settingEncounterRole: '',


### PR DESCRIPTION
## **JIRA TICKET NAME:**
[OEUI-100: Checking the existence of encounter type.](https://issues.openmrs.org/browse/OEUI-100)

### SUMMARY:
This entails checking whether the encounter role whose name was set as a global property exists. If this encounter role does not exist then a user should get an error message on loading the drug order page.

This handle logic for validating proper and complete setup of the encounterRole configurations and notifies the user if not.
i.e `if return axiosInstance.get(encounterrole?q=${value})` is not successful, then an error is displayed like for *Configuration for encounterRole is incomplete*  