### PR TITLE
OEUI-115: Bug fix to fetch past orders after an active order is edited or discontinued

### DIFF
--- a/app/js/actions/addDrugOrder.js
+++ b/app/js/actions/addDrugOrder.js
@@ -7,6 +7,7 @@ import axiosInstance from '../config';
 import networkError from './networkError';
 import loading from './loading';
 import activeOrderAction from './activeOrderAction';
+import { getPastOrders } from '../actions/pastOrders';
 
 export const postDrugOrderSuccess = response => ({
   type: POST_DRUG_ORDER_SUCCESS,
@@ -25,6 +26,7 @@ export const postDrugOrder = (ordersPayload, limit, startIndex, patientUuid, car
       .then((response) => {
         dispatch(postDrugOrderSuccess(response));
         dispatch(activeOrderAction(limit, startIndex, patientUuid, careSetting));
+        dispatch(getPastOrders(limit, startIndex, patientUuid, careSetting));
       }).catch((error) => {
         dispatch(loading('POST_DRUG_ORDER', false));
         if (error.response) {

--- a/tests/actions/addDrugOrder.test.js
+++ b/tests/actions/addDrugOrder.test.js
@@ -9,6 +9,7 @@ import {
     POST_DRUG_ORDER_SUCCESS,
     POST_DRUG_ORDER_FAILURE,
     FETCH_ACTIVE_ORDER_LOADING,
+    LOAD_PAST_ORDERS_LOADING,
 } from '../../app/js/actions/actionTypes';
 
 
@@ -45,6 +46,7 @@ describe('addDrugOrder post thunk', () => {
             POST_DRUG_ORDER_LOADING,
             POST_DRUG_ORDER_SUCCESS,
             FETCH_ACTIVE_ORDER_LOADING,
+            LOAD_PAST_ORDERS_LOADING,
         ]
         await store.dispatch(postDrugOrder(payload))
         .then ( () => {


### PR DESCRIPTION
## JIRA TICKET NAME:
[OEUI-115: Bug fix to fetch past orders after an active order is edited or discontinued](https://issues.openmrs.org/browse/OEUI-115)
### SUMMARY:
Currently, when an active order is edited or discontinued, the user would need to reload the page to see the order under the `Past Drug Orders` tab. This ticket is a bug fix to implement.