### PR TITLE
OEUI-121: Show pagination only when orders are more than one page

### DIFF
--- a/app/js/components/orderEntry/ActiveOrders.jsx
+++ b/app/js/components/orderEntry/ActiveOrders.jsx
@@ -232,31 +232,34 @@ export class ActiveOrders extends React.Component {
             {this.showOrders(activeOrders)}
           </tbody>
         </table>
-        <div className="clear">
-          <div className="float-left-padding">
-            {this.props.showResultCount}
-          </div>
-          <div className="dataTables_paginate">
-            <ReactPaginate
-              pageCount={this.state.pageCount}
-              pageRangeDisplayed={5}
-              marginPagesDisplayed={3}
-              previousLabel="Previous"
-              nextLabel="Next"
-              breakClassName="text-align-center"
-              initialPage={0}
-              containerClassName="react-paginate-container"
-              pageLinkClassName="page-link"
-              activeClassName="active-link"
-              disabledClassName="active-link"
-              nextLinkClassName="page-link"
-              previousLinkClassName="page-link"
-              onPageChange={this.onPageChange}
-              forcePage={this.state.pageNumber}
-              disableInitialCallback
-            />
-          </div>
-        </div>
+        {
+          this.props.pageCount !== 1 &&
+            <div className="clear">
+              <div className="float-left-padding">
+                {this.props.showResultCount}
+              </div>
+              <div className="dataTables_paginate">
+                <ReactPaginate
+                  pageCount={this.state.pageCount}
+                  pageRangeDisplayed={5}
+                  marginPagesDisplayed={3}
+                  previousLabel="Previous"
+                  nextLabel="Next"
+                  breakClassName="text-align-center"
+                  initialPage={0}
+                  containerClassName="react-paginate-container"
+                  pageLinkClassName="page-link"
+                  activeClassName="active-link"
+                  disabledClassName="active-link"
+                  nextLinkClassName="page-link"
+                  previousLinkClassName="page-link"
+                  onPageChange={this.onPageChange}
+                  forcePage={this.state.pageNumber}
+                  disableInitialCallback
+                />
+              </div>
+            </div>
+        }
       </div>
     );
   }

--- a/app/js/components/orderEntry/PastOrders.jsx
+++ b/app/js/components/orderEntry/PastOrders.jsx
@@ -77,31 +77,34 @@ export class PastOrders extends React.Component {
                   <PastOrder key={pastOrder.uuid} {...pastOrder} />)}
               </tbody>
             </table>
-            <div className="clear">
-              <div className="float-left-padding">
-                {this.props.showResultCount}
-              </div>
-              <div className="dataTables_paginate">
-                <ReactPaginate
-                  pageCount={this.state.pageCount}
-                  pageRangeDisplayed={5}
-                  marginPagesDisplayed={3}
-                  previousLabel="Previous"
-                  nextLabel="Next"
-                  breakClassName="text-align-center"
-                  initialPage={0}
-                  containerClassName="react-paginate-container"
-                  pageLinkClassName="page-link"
-                  activeClassName="active-link"
-                  disabledClassName="active-link"
-                  nextLinkClassName="page-link"
-                  previousLinkClassName="page-link"
-                  onPageChange={this.onPageChange}
-                  forcePage={this.state.pageNumber}
+            {
+              this.props.pageCount !== 1 &&
+                <div className="clear">
+                  <div className="float-left-padding">
+                    {this.props.showResultCount}
+                  </div>
+                  <div className="dataTables_paginate">
+                    <ReactPaginate
+                      pageCount={this.state.pageCount}
+                      pageRangeDisplayed={5}
+                      marginPagesDisplayed={3}
+                      previousLabel="Previous"
+                      nextLabel="Next"
+                      breakClassName="text-align-center"
+                      initialPage={0}
+                      containerClassName="react-paginate-container"
+                      pageLinkClassName="page-link"
+                      activeClassName="active-link"
+                      disabledClassName="active-link"
+                      nextLinkClassName="page-link"
+                      previousLinkClassName="page-link"
+                      onPageChange={this.onPageChange}
+                      forcePage={this.state.pageNumber}
                   disableInitialCallback={true} // eslint-disable-line
-                />
-              </div>
-            </div>
+                    />
+                  </div>
+                </div>
+            }
           </div>
           : <p id="no_past_orders">No Past Orders</p>}
         <div />


### PR DESCRIPTION
## JIRA TICKET NAME

[OEUI-121:  Show pagination only when orders are more than one page](https://issues.openmrs.org/browse/OEUI-121)

## SUMMARY:
This ticket is based on feedback on [Talk](https://talk.openmrs.org/t/order-entry-ui-sprint-4-announcement/17921/76). It entails refactoring the pagination implementation to only show pagination when the orders are more the specified limit for a single page. That is, the pagination starts showing when orders spill into page 2 or more.

This implementation should be done for both active and past orders.