### PR TITLE
OEUI-120: Change text to match implementation in existing omod

### DIFF
--- a/__mocks__/mockData.js
+++ b/__mocks__/mockData.js
@@ -93,6 +93,22 @@ export default {
       orderNumber: 3,
     },
   ],
+  freeTextOrder: {
+    action: 'NEW',
+    drugInstructions: 'After a meal',
+    drugName: 'syrup',
+    orderNumber: 3,
+  },
+  standardDoseOrder: {
+    action: 'NEW',
+    dose: 8,
+    dosingUnit: 'kg',
+    frequency: 'daily',
+    route: 'oral',
+    drugInstructions: 'After a meal',
+    drugName: 'syrup',
+    orderNumber: 4,
+  },
   addedOrder: {
     data: {},
   },

--- a/app/js/components/orderEntry/SearchAndAddOrder.jsx
+++ b/app/js/components/orderEntry/SearchAndAddOrder.jsx
@@ -129,55 +129,56 @@ export class SearchAndAddOrder extends React.Component {
   )
 
   render() {
+    const { outpatientCareSetting, inpatientCareSetting, location } = this.props;
     return (
       <div className="body-wrapper">
         <Tabs>
           <Tab
-            tabName="OutPatient">
+            tabName={outpatientCareSetting.display}>
             {this.renderSearchDrug()}
-            {this.renderAddForm(this.props.outpatientCareSetting)}
-            {this.renderDraftDataTable(this.props.outpatientCareSetting)}
+            {this.renderAddForm(outpatientCareSetting)}
+            {this.renderDraftDataTable(outpatientCareSetting)}
             <Accordion open title="Active Drug Orders">
               <ActiveOrders
                 isDelete={this.state.isDelete}
                 onDelete={this.onDelete}
-                tabName="OutPatient"
-                careSetting={this.props.outpatientCareSetting}
-                location={this.props.location}
+                tabName={outpatientCareSetting.display}
+                careSetting={outpatientCareSetting}
+                location={location}
                 handleEditActiveDrugOrder={this.handleEditActiveDrugOrder}
               />
             </Accordion>
 
             <Accordion title="Past Drug Orders">
               <PastOrders
-                tabName="OutPatient"
-                careSetting={this.props.outpatientCareSetting}
-                location={this.props.location} />
+                tabName="Outpatient"
+                careSetting={outpatientCareSetting}
+                location={location} />
 
               <br />
             </Accordion>
           </Tab>
           <Tab
-            tabName="InPatient">
+            tabName={inpatientCareSetting.display}>
             {this.renderSearchDrug()}
-            {this.renderAddForm(this.props.inpatientCareSetting)}
+            {this.renderAddForm(inpatientCareSetting)}
             {this.renderDraftDataTable(this.props.inpatientCareSetting)}
             <Accordion open title="Active Drug Orders">
               <ActiveOrders
                 isDelete={this.state.isDelete}
                 onDelete={this.onDelete}
-                tabName="InPatient"
-                careSetting={this.props.inpatientCareSetting}
-                location={this.props.location}
+                tabName={inpatientCareSetting.display}
+                careSetting={inpatientCareSetting}
+                location={location}
                 handleEditActiveDrugOrder={this.handleEditActiveDrugOrder}
               />
             </Accordion>
 
             <Accordion title="Past Drug Orders">
               <PastOrders
-                tabName="InPatient"
-                careSetting={this.props.inpatientCareSetting}
-                location={this.props.location} />
+                tabName="Inpatient"
+                careSetting={inpatientCareSetting}
+                location={location} />
             </Accordion>
 
           </Tab>

--- a/app/js/components/orderEntry/addForm/DraftDataTable.jsx
+++ b/app/js/components/orderEntry/addForm/DraftDataTable.jsx
@@ -145,9 +145,12 @@ export class DraftDataTable extends React.Component {
         {dosingUnit && ` ${dosingUnit},`}
         {frequency && ` ${frequency},`}
         {route && ` ${route}`}
+        {reason && `, as needed for ${reason}`}
         {duration && `, for ${duration} ${durationUnit} total`}
-        {reason && `, (Reason: ${reason})`}
-        {drugInstructions && ` (${drugInstructions})`}
+        {dose ?
+          drugInstructions && ` (${drugInstructions})` :
+          drugInstructions && ` "${drugInstructions}"`
+        }
         {dispensingQuantity && ` (Dispense: ${dispensingQuantity} ${dispensingUnit})`}
       </p>
     );

--- a/app/js/components/orderEntry/addForm/FreeText.jsx
+++ b/app/js/components/orderEntry/addForm/FreeText.jsx
@@ -101,7 +101,7 @@ const FreeText = ({
               onClick={handleSubmit}
               disabled={activateSaveButton()}
             >
-            Save
+            Add
             </button>
           </div>
         </div>

--- a/app/js/components/orderEntry/addForm/StandardDose.jsx
+++ b/app/js/components/orderEntry/addForm/StandardDose.jsx
@@ -274,7 +274,7 @@ const StandardDose = ({
               className="confirm"
               onClick={handleSubmit}
               disabled={activateSaveButton()}>
-                Save
+                Add
             </button>
           </div>
         </div>

--- a/tests/components/orderentry/addForm/DraftDataTable.test.jsx
+++ b/tests/components/orderentry/addForm/DraftDataTable.test.jsx
@@ -15,6 +15,8 @@ const {
   addedOrderError,
   items,
   itemName,
+  freeTextOrder,
+  standardDoseOrder,
 } = mockData;
 
 const props = {
@@ -133,5 +135,26 @@ describe('behaviour when adding an order fails', () => {
     sinon.spy(renderedComponent, 'addDrugOrder');
     renderedComponent.addDrugOrder(event);
     expect(renderedComponent.addDrugOrder.calledOnce).toEqual(true);
+  });
+});
+
+describe('details rendered by draft table', () => {
+  it('should render standard dose draft order details', () => {
+    const newProps = {...props, draftOrders: [standardDoseOrder]};
+    const { drugName, dosingUnit, dose, frequency, route, drugInstructions } = standardDoseOrder;
+    const wrapper = shallow(<DraftDataTable {...newProps} store={store} />);
+    wrapper.instance().showOrders(props.draftOrders);
+    expect(wrapper.find('div').text()).toContain(
+      `${drugName}: ${dose} ${dosingUnit}, ${frequency}, ${route} (${drugInstructions})`
+    );
+  });
+  it('should render free text dose draft order details', () => {
+    const newProps = {...props, draftOrders: [freeTextOrder]};
+    const { drugName, drugInstructions } = standardDoseOrder;
+    const wrapper = shallow(<DraftDataTable {...newProps} store={store} />);
+    wrapper.instance().showOrders(props.draftOrders);
+    expect(wrapper.find('div').text()).toContain(
+      `${drugName}: "${drugInstructions}"`
+    );
   });
 });


### PR DESCRIPTION
### JIRA TICKET NAME 
[OEUI-120: Change text to match implementation in existing omod](https://issues.openmrs.org/browse/OEUI-120)

## Summary:
This ticket is based on the feedback from [talk](https://talk.openmrs.org/t/order-entry-ui-sprint-4-announcement/17921/76). 
- Changes the text on the button clicked to add a draft order from Save to Add.
- Changes tab names from OutPatient to Outpatient, InPatient to Inpatient.
- Optimises draft order text and change Reason to As needed