### PR TITLE
OEUI-123: show details of order being discontinued

### DIFF
--- a/app/css/openmrs-owa-orderentry.css
+++ b/app/css/openmrs-owa-orderentry.css
@@ -324,3 +324,7 @@ body {
     float: left;
     padding-top: 5px;
 }
+
+.table-container {
+    overflow-x: auto;
+}

--- a/app/js/components/orderEntry/addForm/DraftDataTable.jsx
+++ b/app/js/components/orderEntry/addForm/DraftDataTable.jsx
@@ -155,9 +155,14 @@ export class DraftDataTable extends React.Component {
       </p>
     );
 
+    let formattedDetails = details.props.children.join("");
+    if (formattedDetails.length > 155) {
+      formattedDetails = `${formattedDetails.substring(0, 155)}...`;
+    }
+
     const discontinueForm = (
       <div>
-        <p> Discontinue {drugName} </p>
+        <p className="discontinue-drug"><em>{formattedDetails}</em></p>
         <p className="left label-margin">
           <label name="reason">For</label>
         </p>
@@ -197,22 +202,23 @@ export class DraftDataTable extends React.Component {
 
   render() {
     const { draftOrders, handleDiscardAllOrders } = this.props;
-
     return (
       <div className="draft-spacing">
         <h2>Unsaved Draft Orders ({draftOrders.length})</h2>
-        <table className="table bordered mw-958-px">
-          <thead>
-            <tr>
-              <th className="w-120-px">Status</th>
-              <th>Details</th>
-              <th className="w-81-px">Actions</th>
-            </tr>
-          </thead>
-          <tbody>
-            {this.showOrders(draftOrders)}
-          </tbody>
-        </table>
+        <div className="table-container">
+          <table className="table bordered mw-958-px">
+            <thead>
+              <tr>
+                <th className="w-120-px">Status</th>
+                <th>Details</th>
+                <th className="w-81-px">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {this.showOrders(draftOrders)}
+            </tbody>
+          </table>
+        </div>
         <br />
         <input
           type="button"
@@ -296,7 +302,7 @@ DraftDataTable.propTypes = {
 };
 
 DraftDataTable.defaultProps = {
-  handleEditDraftOrder: () => {},
+  handleEditDraftOrder: () => { },
   addOrderError: {},
   encounterRole: {},
 };

--- a/tests/components/orderentry/addForm/DraftDataTable.test.jsx
+++ b/tests/components/orderentry/addForm/DraftDataTable.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { DraftDataTable } from '../../../../app/js/components/orderEntry/addForm/DraftDataTable';
+import ConnectedDraftTable, { DraftDataTable } from '../../../../app/js/components/orderEntry/addForm/DraftDataTable';
 
 const {
   encounterRole,
@@ -19,25 +19,25 @@ const {
   standardDoseOrder,
 } = mockData;
 
-const props = {
-    postDrugOrder: jest.fn(() => Promise.resolve(123)),
-    getOrderEntryConfigurations: jest.fn(),
-    fetchEncounterType: jest.fn(),
-    fetchEncounterRole: jest.fn(),
-    handleDiscardOneOrder: jest.fn(),
-    handleDiscardAllOrders: jest.fn(),
-    encounterRole: encounterRole.results,
-    allConfigurations,
-    sessionReducer,
-    encounterType,
-    orders,
-    patient,
-    careSetting,
-    draftOrders,
-    addedOrder,
-    addedOrderError,
-    items,
-    itemName,
+let props = {
+  postDrugOrder: jest.fn(() => Promise.resolve(123)),
+  getOrderEntryConfigurations: jest.fn(),
+  fetchEncounterType: jest.fn(),
+  fetchEncounterRole: jest.fn(),
+  handleDiscardOneOrder: jest.fn(),
+  handleDiscardAllOrders: jest.fn(),
+  encounterRole: encounterRole.results,
+  allConfigurations,
+  sessionReducer,
+  encounterType,
+  orders,
+  patient,
+  careSetting,
+  draftOrders,
+  addedOrder,
+  addedOrderError,
+  items,
+  itemName,
 };
 
 let mountedComponent;
@@ -66,10 +66,28 @@ describe('Draft Data Table', () => {
     expect(props.handleDiscardOneOrder.mock.calls.length).toEqual(0);
     expect(wrapper).toMatchSnapshot()
   });
+
+  it('should truncate text longer than 155 characters', () => {
+    props = {
+      ...props,
+      draftOrders: [
+        {
+          action: 'DISCONTINUE',
+          drugName: '',
+          drugInstructions: 'Take 2 tablets, with warm water or lime in the morning (before meal) and evening (after meal). Not to be taken with alcohol neither should ne taken by before or while driving',
+          orderNumber: 3,
+        }
+      ]
+    }
+    mountedComponent = undefined;
+    const wrapper = getComponent().find('.discontinue-drug em');
+    let text = `: "${props.draftOrders[0].drugInstructions}`;
+    expect(wrapper.props().children).toBe(`${text.substring(0,155)}...`);
+  });
 });
 
 describe('addDrugOrder(event) method', () => {
-  const event = { preventDefault: () => {} };
+  const event = { preventDefault: () => { } };
   beforeEach(() => {
     jest.spyOn(event, 'preventDefault');
   });
@@ -93,7 +111,7 @@ describe('getUUID() method', () => {
 describe('showOrders() method', () => {
   it('should call showOrders() and no click events', () => {
     const mockCallBack = jest.fn();
-    const wrapper = shallow(<DraftDataTable onClick={mockCallBack} {...props}/>);
+    const wrapper = shallow(<DraftDataTable onClick={mockCallBack} {...props} />);
     wrapper.find('#edit-draft-order').simulate('click');
     wrapper.find('#discard-draft-order').simulate('click');
     const renderedComponent = getComponent().instance();
@@ -122,11 +140,11 @@ describe('behaviour when adding an order fails', () => {
       careSetting,
       draftOrders,
       addedOrder: {},
-      addedOrderError: { data : { error: { message: ''} } },
+      addedOrderError: { data: { error: { message: '' } } },
       items,
       itemName,
-  };
-    const event = { preventDefault: () => {} };
+    };
+    const event = { preventDefault: () => { } };
     beforeEach(() => {
       jest.spyOn(event, 'preventDefault');
     });
@@ -144,7 +162,7 @@ describe('details rendered by draft table', () => {
     const { drugName, dosingUnit, dose, frequency, route, drugInstructions } = standardDoseOrder;
     const wrapper = shallow(<DraftDataTable {...newProps} store={store} />);
     wrapper.instance().showOrders(props.draftOrders);
-    expect(wrapper.find('div').text()).toContain(
+    expect(wrapper.find('div').first().text()).toContain(
       `${drugName}: ${dose} ${dosingUnit}, ${frequency}, ${route} (${drugInstructions})`
     );
   });
@@ -153,8 +171,27 @@ describe('details rendered by draft table', () => {
     const { drugName, drugInstructions } = standardDoseOrder;
     const wrapper = shallow(<DraftDataTable {...newProps} store={store} />);
     wrapper.instance().showOrders(props.draftOrders);
-    expect(wrapper.find('div').text()).toContain(
+    expect(wrapper.find('div').first().text()).toContain(
       `${drugName}: "${drugInstructions}"`
     );
+  });
+});
+
+describe('Connected DraftDataTable component', () => {
+  it('component successfully rendered', () => {
+    const store = mockStore({
+      draftTableReducer: { draftOrders },
+      drugSearchReducer: { selected: "para" },
+      patientReducer: {
+        patient,
+      },
+      encounterReducer: { encounterType },
+      encounterRoleReducer: { encounterRole },
+      addDrugOrderReducer: { addedOrder, error: addedOrderError },
+      sessionReducer: {},
+      allConfigurations: {}
+    });
+    const wrapper = shallow(<ConnectedDraftTable store={store} />);
+    expect(wrapper.length).toBe(1);
   });
 });


### PR DESCRIPTION
## **JIRA TICKET NAME:**
[OEUI-123: Show details of order being discontinued.](https://issues.openmrs.org/browse/OEUI-123)

### SUMMARY:
This ticket is based on feedback from Talk. When an active order is being discontinued, the entire details of the current order should be displayed for more context, not just the drug name.