### PR TITLE
OEUI-129: Populate new order for field when editing a drug order.

### DIFF
--- a/app/js/components/searchDrug/index.jsx
+++ b/app/js/components/searchDrug/index.jsx
@@ -38,7 +38,7 @@ export class SearchDrug extends React.Component {
         results={this.props.drugSearch.drugs}
         loading={this.props.drugSearch.loading}
         error={this.props.drugSearch.error}
-        value={this.props.value}
+        value={this.props.drugSearch.selected.display || this.props.value}
       />
     );
   }

--- a/tests/components/searchDrug/index.test.jsx
+++ b/tests/components/searchDrug/index.test.jsx
@@ -23,8 +23,10 @@ describe('Component: SearchDrug: Container', () => {
   beforeEach(() => {
     props = {
       drugSearch: {
+        selected: {},
         drugs: []
       },
+      value: 'paracetamol',
       searchDrug: jest.fn(),
       onChange: jest.fn(),
       onOptionSelected: jest.fn(),


### PR DESCRIPTION
## JIRA TICKET NAME

[OEUI-129:  Populate new order for field when editing a drug order.](https://issues.openmrs.org/browse/OEUI-129)

## SUMMARY:
When editing a new drug order, the new drug order for field is unpopulated. The field needs to be populated with the name of the drug order being edited.  