### PR TITLE
OEUI-128: Correct tooltips with incorrect labels

### DIFF
--- a/app/js/components/orderEntry/ActiveOrders.jsx
+++ b/app/js/components/orderEntry/ActiveOrders.jsx
@@ -177,7 +177,7 @@ export class ActiveOrders extends React.Component {
             </a>
             <a > <i
               className="icon-remove icon-color"
-              title="Delete"
+              title="Discontinue"
               id="delete"
               role="button"
               tabIndex="0"

--- a/app/js/components/orderEntry/addForm/DraftDataTable.jsx
+++ b/app/js/components/orderEntry/addForm/DraftDataTable.jsx
@@ -187,7 +187,7 @@ export class DraftDataTable extends React.Component {
             <i className="icon-edit" title="Edit" />
           </a>
           <a id="discard-draft-order" href="#" onClick={() => handleDiscardOneOrder(order)}>
-            <i className="icon-remove" title="Delete" />
+            <i className="icon-remove" title="Discard" />
           </a>
         </td>
       </tr>


### PR DESCRIPTION
## JIRA TICKET NAME

[OEUI-128:  Correct tooltips with incorrect labels](https://issues.openmrs.org/browse/OEUI-128)

## SUMMARY:
The wording for some tooltips does not correspond to what the buttons actually do.

Tooltip for edit draft drug order showing `delete` instead of `edit`.
Tooltip for discontinue draft drug order showing `delete` instead of `discontinue`
Plus any other tooltips that need to be corrected.