### PR TITLE
OEUI-125: Inconsistent date format on Order Entry display page

### DIFF
--- a/app/js/components/orderEntry/ActiveOrders.jsx
+++ b/app/js/components/orderEntry/ActiveOrders.jsx
@@ -191,7 +191,7 @@ export class ActiveOrders extends React.Component {
       return (
         <tr key={uuid} >
           <td>
-            {format(dateActivated, 'MM-DD-YYYY HH:mm')} {autoExpireDate && (`- ${format(autoExpireDate, 'MM-DD-YYYY HH:mm')}`)}
+            {format(dateActivated, 'DD-MMM-YYYY HH:mm')} {autoExpireDate && (`- ${format(autoExpireDate, 'DD-MMM-YYYY HH:mm')}`)}
           </td>
           {details}
           <td className="text-center action-padding" >

--- a/app/js/components/orderEntry/PastOrder.jsx
+++ b/app/js/components/orderEntry/PastOrder.jsx
@@ -37,7 +37,7 @@ export const PastOrder = (props) => {
   return (
     <tr>
       <td>
-        {format(auditInfo.dateCreated, 'DD-MM-YYYY HH:MM')} {autoExpireDate && `- ${format(autoExpireDate, 'DD-MM-YYYY HH:MM')}`}
+        {format(auditInfo.dateCreated, 'DD-MMM-YYYY HH:MM')} {autoExpireDate && `- ${format(autoExpireDate, 'DD-MMM-YYYY HH:MM')}`}
       </td>
       <td>
         {details}


### PR DESCRIPTION
[OEUI-125: Inconsistent date format on Order Entry display page](https://issues.openmrs.org/browse/OEUI-125)

### SUMMARY: 
The date format on the current order entry display page is inconsistent.  For Active orders it looks like it is using MM-DD-YYYY and for Past orders it is using DD-MM-YYYY.
These should be the same.  And since both of these formats could be confusing, especially when used by multiple countries following different conventions, I have used DD MMM YYYY, according to feedback.  That way, for example, the date will show as 6 May 2018 instead of 5-6-2018 or 6-5-2018.