### PR TITLE
OEUI-126: Clear and close drug forms and unsaved draft orders table on switching between Inpatient and Outpatient tabs

### DIFF
--- a/app/js/components/orderEntry/SearchAndAddOrder.jsx
+++ b/app/js/components/orderEntry/SearchAndAddOrder.jsx
@@ -98,6 +98,12 @@ export class SearchAndAddOrder extends React.Component {
     });
   }
 
+  closeFormsOnTabChange = () => {
+    this.clearSearchField();
+    this.props.selectDrugSuccess();
+    this.props.deleteAllDraftOrders();
+  }
+
   renderSearchDrug = () => (
     this.state.editDrugName ?
       <p className="revise-order-padding">
@@ -143,7 +149,9 @@ export class SearchAndAddOrder extends React.Component {
     const { outpatientCareSetting, inpatientCareSetting, location } = this.props;
     return (
       <div className="body-wrapper">
-        <Tabs>
+        <Tabs
+          closeFormsOnTabChange={this.closeFormsOnTabChange}
+        >
           <Tab
             tabName={outpatientCareSetting.display}>
             {this.renderSearchDrug()}

--- a/app/js/components/orderEntry/addForm/AddForm.jsx
+++ b/app/js/components/orderEntry/addForm/AddForm.jsx
@@ -48,7 +48,10 @@ export class AddForm extends React.Component {
     this.props.getOrderEntryConfigurations();
   }
 
-  componentDidUpdate() {
+  componentDidUpdate(prevProps) {
+    if (prevProps.careSetting.display !== this.props.careSetting.display) {
+      this.clearDrugForms();
+    }
     return (
       Object.keys(this.props.draftOrder).length ||
       Object.keys(this.props.editOrder).length
@@ -208,9 +211,9 @@ export class AddForm extends React.Component {
     this.props.clearSearchField();
     this.props.setOrderAction('DISCARD_ONE', this.props.orderNumber);
   }
-
   clearDrugForms = () => {
     this.setState({
+      action: 'NEW',
       fields: {
         dose: '',
         dosingUnit: '',
@@ -218,13 +221,25 @@ export class AddForm extends React.Component {
         route: '',
         duration: '',
         durationUnit: '',
-        dispensingUnit: '',
         dispensingQuantity: '',
+        dispensingUnit: '',
         reason: '',
         drugInstructions: '',
       },
-      action: 'NEW',
       previousOrder: null,
+      fieldErrors: {
+      },
+      orderNumber: 0,
+      formType: 'Standard Dosage',
+      dosingType: '',
+      activeTabIndex: 0,
+      options: {
+        dosingUnit: [],
+        frequency: [],
+        route: [],
+        durationUnit: [],
+        dispensingUnit: [],
+      },
     });
   }
 

--- a/app/js/components/tabs/Tabs.jsx
+++ b/app/js/components/tabs/Tabs.jsx
@@ -10,6 +10,7 @@ class Tabs extends Component {
       this.setState({
         activeTabIndex: tabIndex,
       });
+      this.props.closeFormsOnTabChange();
     }
 
     passPropsToChildren = () => (
@@ -42,6 +43,7 @@ class Tabs extends Component {
 Tabs.propTypes = {
   defaultActiveTabIndex: PropTypes.number,
   children: PropTypes.node.isRequired,
+  closeFormsOnTabChange: PropTypes.func.isRequired,
 };
 
 Tabs.defaultProps = {

--- a/tests/components/orderentry/SearchAndAddOrder.test.jsx
+++ b/tests/components/orderentry/SearchAndAddOrder.test.jsx
@@ -117,6 +117,15 @@ describe('handleEditDraftOrder() method', () => {
   });
 });
 
+describe('closeFormsOnTabChange() method', () => {
+  it('should call closeFormsOnTabChange()', () => {
+    const renderedComponent = getComponent().instance();
+    sinon.spy(renderedComponent, 'closeFormsOnTabChange');
+    renderedComponent.closeFormsOnTabChange();
+    expect(renderedComponent.closeFormsOnTabChange.calledOnce).toEqual(true);
+  });
+});
+
 
 const setup = () => {
   const wrapper = shallow(<SearchAndAddOrder {...props} store={store} />);
@@ -145,7 +154,7 @@ describe('handleDiscardAllOrders', () => {
     const { wrapper } = setup();
 
     wrapper.instance().handleDiscardAllOrders();
-    expect(props.deleteAllDraftOrders.mock.calls.length).toEqual(1);
+    expect(props.deleteAllDraftOrders.mock.calls.length).toEqual(2);
   });
 });
 

--- a/tests/components/orderentry/addForm/AddForm.test.jsx
+++ b/tests/components/orderentry/addForm/AddForm.test.jsx
@@ -247,7 +247,7 @@ describe('handleSubmitDrugForm() method', () => {
     expect(getComponent().state('draftOrder')).toEqual({
       action: "NEW",
       careSetting: undefined,
-      dosingType: "org.openmrs.FreeTextDosingInstructions",
+      dosingType: "org.openmrs.SimpleDosingInstructions",
       drug: "AJJJKW7378JHJ",
       drugName: "Paracentamol",
       orderNumber: 1,
@@ -265,5 +265,19 @@ describe('handleSubmitDrugForm() method', () => {
       reason: "",
       route: "",
     });
+  });
+});
+
+describe('componentWillReceiveProps()', () => {
+  it('does not call clearDrugForms when props is the same', () => {
+      const renderedComponent = getComponent().instance();
+      getComponent().setProps({ careSetting: { display: 'Inpatient' } })
+      expect(renderedComponent.clearDrugForms.calledOnce).toEqual(false);
+
+      getComponent().setProps({ careSetting: { display: 'Inpatient' } })
+      const props1 = getComponent().props();
+      getComponent().setProps({ careSetting: { display: 'Outpatient' } })
+      const props2 = getComponent().props();
+      expect(props1 !== props2).toEqual(true);
   });
 });

--- a/tests/components/tabs/Tabs.test.js
+++ b/tests/components/tabs/Tabs.test.js
@@ -26,8 +26,12 @@ describe('`Tabs` component', () => {
     });
 
     it('should change the content when active index changes', () => {
-        const careSetting = jest.fn();
-        const wrapper = mount(<Tabs defaultActiveTabIndex={1} careSetting={careSetting}>
+        const props = {
+            careSetting : jest.fn(),
+            closeFormsOnTabChange: jest.fn(),
+            clearSearchField: jest.fn(),
+        }
+        const wrapper = mount(<Tabs defaultActiveTabIndex={1} {...props}>
             <div tabName="tab 1"><p>Content 1</p></div>
             <div tabName="tab 2"><p>Content 2</p></div>
             <div tabname="tab 3"><p>Content 3</p></div>


### PR DESCRIPTION
# **JIRA TICKET NAME:**

[OEUI-126: Clear and close drug forms and unsaved draft orders table on switching between Inpatient and Outpatient tabs](https://issues.openmrs.org/browse/OEUI-126)

## **SUMMARY:**

The Inpatient and Outpatient tabs on the Order Entry UI seem to share the same entry form.  By this I mean it is possible to switch between the two tabs as the user is filling out the form.  It is saved to Inpatient or Outpatient based on which tab is chosen when the user clicks save.  This can cause some confusion as there are different fields for the two tabs: e.g. The user may start in the Outpatient Tab, which includes dispensing units and then switch over to Inpatient and save, which would result in an Inpatient order with dispensing units filled out.  

It is also a little confusing during editing.  If you edit an Inpatient order, you can switch over to Outpatient.  If you try to save it like this, you will get a Toast message with the error "the care setting does not match that of the previous order".  It's good that it does this, but the user should not be allowed to attempt to edit an Inpatient order on the Outpatient tab.

 

It seems these 2 tabs should be separate and draft/edited orders should not be shared between them.