### PR TITLE
OEUI-118: Widen drug prescription field boxes

### DIFF
--- a/app/css/openmrs-owa-orderentry.css
+++ b/app/css/openmrs-owa-orderentry.css
@@ -244,7 +244,7 @@ body {
     max-height: 500px;
     overflow-x: scroll;
     background-color: #fff;
-    width: 352px;
+    width: 622px;
 }
 
 .search-container {
@@ -254,7 +254,16 @@ body {
 .search-container input {
     padding: 5px 10px;
     margin-top: 5px;
-    width: 330px;
+    width: 600px;
+}
+
+@media only screen and (max-width: 600px) {
+    .search-container input {
+        width: 300px;
+    }
+    .options-container {
+        width: 322px;
+    }
 }
 
 .option {
@@ -341,3 +350,8 @@ body {
     color:#02473f;
     font-size: 20px
 }
+.flex-row {
+    display: flex;
+    flex-wrap: wrap;
+}
+

--- a/app/js/components/orderEntry/addForm/FreeText.jsx
+++ b/app/js/components/orderEntry/addForm/FreeText.jsx
@@ -16,8 +16,8 @@ const FreeText = ({
   return (
     <div>
       <form className="simple-form-ui">
-        <div className="grid-row">
-          <div className="column-6">
+        <div className="flex-row">
+          <div>
             <label name="notes">Complete Instructions</label>
             <textarea
               rows="4"
@@ -30,8 +30,8 @@ const FreeText = ({
           </div>
         </div>
         {(careSetting.display === "Outpatient") &&
-          <div className="grid-row">
-            <div className="column-7">
+          <div className="flex-row">
+            <div>
               <label>For outpatient orders </label>
               <p className="left label-margin">
                 <label>Dispense:</label>
@@ -60,7 +60,7 @@ const FreeText = ({
                   name="dispensingUnit"
                   id="drugDispensingUnits"
                   list="dispensingUnits"
-                  size="8"
+                  size="20"
                   value={fields.dispensingUnit}
                   onBlur={handleValidation}
                   onChange={handleChange} />
@@ -81,8 +81,8 @@ const FreeText = ({
             </div>
           </div>}
         <br />
-        <div className="grid-row">
-          <div className="column-1">
+        <div className="flex-row">
+          <div>
             <button
               type="button"
               className="cancel"

--- a/app/js/components/orderEntry/addForm/StandardDose.jsx
+++ b/app/js/components/orderEntry/addForm/StandardDose.jsx
@@ -19,8 +19,8 @@ const StandardDose = ({
   return (
     <div>
       <form className="simple-form-ui">
-        <div className="grid-row">
-          <div className="column-10">
+        <div className="flex-row">
+          <div>
             <p className="left p-margin">
               <input
                 className={`small-input ${fieldErrors.dose ? "illegalValue" : ""}`}
@@ -47,7 +47,7 @@ const StandardDose = ({
                 id="drugDosingUnits"
                 name="dosingUnit"
                 list="dosingUnits"
-                size="7"
+                size="20"
                 value={fields.dosingUnit}
                 onBlur={handleValidation}
                 onChange={handleChange}
@@ -74,7 +74,7 @@ const StandardDose = ({
                 id="frequency"
                 name="frequency"
                 list="orderFrequencies"
-                size="20"
+                size="40"
                 value={fields.frequency}
                 onBlur={handleValidation}
                 onChange={handleChange} />
@@ -122,8 +122,8 @@ const StandardDose = ({
             </p>
           </div>
         </div>
-        <div className="grid-row">
-          <div className="column-7">
+        <div className="flex-row">
+          <div>
             <p className="left label-margin">
               <label name="reason">As needed for</label>
             </p>
@@ -133,14 +133,14 @@ const StandardDose = ({
                 placeholder="reason(optional)"
                 id="reason"
                 type="text"
-                size="30"
+                size="35"
                 onChange={handleChange}
                 value={fields.reason} />
             </p>
           </div>
         </div>
-        <div className="grid-row">
-          <div className="column-7">
+        <div className="flex-row">
+          <div>
             <p className="left label-margin">
               <label>For</label>
             </p>
@@ -162,7 +162,7 @@ const StandardDose = ({
                 name="durationUnit"
                 id="drugDurationUnits"
                 list="durationUnits"
-                size="8"
+                size="20"
                 value={fields.durationUnit}
                 onBlur={handleValidation}
                 onChange={handleChange} />
@@ -187,8 +187,8 @@ const StandardDose = ({
             </p>
           </div>
         </div>
-        <div className="grid-row">
-          <div className="column-6">
+        <div className="flex-row">
+          <div>
             <textarea
               rows="2"
               cols="60"
@@ -199,9 +199,9 @@ const StandardDose = ({
               value={fields.drugInstructions} />
           </div>
         </div>
-        { careSetting.display === 'Outpatient' ?
-          <div className="grid-row">
-            <div className="column-7">
+        {careSetting.display === 'Outpatient' ?
+          <div className="flex-row">
+            <div>
               <label>For outpatient orders </label>
               <p className="left label-margin">
                 <label>Dispense:</label>
@@ -230,7 +230,7 @@ const StandardDose = ({
                   name="dispensingUnit"
                   id="drugDispensingUnits"
                   list="dispensingUnits"
-                  size="8"
+                  size="20"
                   value={fields.dispensingUnit}
                   onBlur={handleValidation}
                   onChange={handleChange} />
@@ -253,8 +253,8 @@ const StandardDose = ({
           </div> :
           <br />
         }
-        <div className="grid-row">
-          <div className="column-1">
+        <div className="flex-row">
+          <div>
             <button
               type="button"
               className="cancel"
@@ -263,13 +263,13 @@ const StandardDose = ({
               Cancel
             </button>
           </div>
-          <div className="column-1 pull-right-8">
+          <div className="-1 pull-right-8">
             <button
               type="button"
               className="confirm"
               onClick={handleSubmit}
               disabled={activateSaveButton()}>
-                Add
+              Add
             </button>
           </div>
         </div>


### PR DESCRIPTION
## **JIRA TICKET NAME:**
[OEUI-118: Widen drug prescription field boxes to accommodate available options.](https://issues.openmrs.org/browse/OEUI-118)

### SUMMARY:
These text and combo boxes should be widened to accommodate the options...

 - the text box at the top of the screen for the drug names should be widened.  e.g. some PIH implementations have a drug name as long as "acitracin 500 internatinal units/gram + neomycin sulphate 0.5 % (0.35 % base) skin-ointment, 15 gram tube".  It doesn't necessary need to be as long as this, but we should make it as long as we can on that page.

 - The Dose and Dispensing Units box should be long enough for "International Units"

 -  The Duration Units should be long enough for "number of occurrences"

 

There could still be issues, as the text in other languages may be longer, but we should make these at least long enough for the English values.