### PR TITLE
OEUI-117: Drop downs options should only be filtered by the first letter 

### DIFF
--- a/app/js/components/orderEntry/addForm/AddForm.jsx
+++ b/app/js/components/orderEntry/addForm/AddForm.jsx
@@ -35,6 +35,13 @@ export class AddForm extends React.Component {
     formType: 'Standard Dosage',
     dosingType: '',
     activeTabIndex: 0,
+    options: {
+      dosingUnit: [],
+      frequency: [],
+      route: [],
+      durationUnit: [],
+      dispensingUnit: [],
+    },
   };
 
   componentDidMount() {
@@ -120,6 +127,7 @@ export class AddForm extends React.Component {
     } = this.props.allConfigurations;
     const { name, value } = event.target;
     let item = false;
+    const options = [];
     switch (name) {
       case 'dosingUnit':
         item = drugDosingUnits.filter(unit => unit.display === value).length > 0;
@@ -148,13 +156,49 @@ export class AddForm extends React.Component {
       fieldErrors: {
         ...this.state.fieldErrors, [name]: !item,
       },
+      options: {
+        ...this.state.options, [name]: options,
+      },
     }); }
   }
 
   handleChange = (event) => {
+    const { name, value } = event.target;
+    const {
+      drugDosingUnits, orderFrequencies, drugRoutes, durationUnits, drugDispensingUnits,
+    } = this.props.allConfigurations;
+    let options;
+    if (value) {
+      switch (name) {
+        case 'dosingUnit':
+          options = drugDosingUnits.filter(unit => (
+            unit.display.toLowerCase().indexOf(value.toLowerCase()) === 0));
+          break;
+        case 'frequency':
+          options = orderFrequencies.filter(frequency => (
+            frequency.display.toLowerCase().indexOf(value.toLowerCase()) === 0));
+          break;
+        case 'route':
+          options = drugRoutes.filter(route => (
+            route.display.toLowerCase().indexOf(value.toLowerCase()) === 0));
+          break;
+        case 'dispensingUnit':
+          options = drugDispensingUnits.filter(unit => (
+            unit.display.toLowerCase().indexOf(value.toLowerCase()) === 0));
+          break;
+        case 'durationUnit':
+          options = durationUnits.filter(unit => (
+            unit.display.toLowerCase().indexOf(value.toLowerCase()) === 0));
+          break;
+        default:
+          // does nothing
+      }
+    }
+
     this.setState({
       ...this.state,
-      fields: { ...this.state.fields, [event.target.name]: event.target.value },
+      fields: { ...this.state.fields, [name]: value },
+      options: { ...this.state.options, [name]: options },
     });
   }
 
@@ -264,7 +308,7 @@ export class AddForm extends React.Component {
             careSetting={this.props.careSetting}
             fields={this.state.fields}
             fieldErrors={this.state.fieldErrors}
-            allConfigurations={this.props.allConfigurations}
+            options={this.state.options}
             handleValidation={this.handleValidation}
             activateSaveButton={this.activateSaveButton}
             handleChange={this.handleChange}
@@ -276,7 +320,7 @@ export class AddForm extends React.Component {
           <FreeText
             fields={this.state.fields}
             fieldErrors={this.state.fieldErrors}
-            allConfigurations={this.props.allConfigurations}
+            options={this.state.options}
             handleValidation={this.handleValidation}
             activateSaveButton={this.activateSaveButton}
             handleChange={this.handleChange}

--- a/app/js/components/orderEntry/addForm/FreeText.jsx
+++ b/app/js/components/orderEntry/addForm/FreeText.jsx
@@ -5,7 +5,7 @@ const FreeText = ({
   fieldErrors,
   careSetting,
   fields,
-  allConfigurations,
+  options,
   handleChange,
   handleSubmit,
   handleCancel,
@@ -66,14 +66,11 @@ const FreeText = ({
                   onChange={handleChange} />
                 <datalist id="dispensingUnits" >
                   {
-                    allConfigurations &&
-                    (
-                      allConfigurations.drugDispensingUnits &&
-                    allConfigurations.drugDispensingUnits.map(unit =>
-                      (
-                        <option key={unit.uuid} value={unit.display} />
-                      ))
-                    )
+                    options.dispensingUnit &&
+                      options.dispensingUnit.map(unit =>
+                        (
+                          <option key={unit.uuid} value={unit.display} />
+                        ))
                   }
                 </datalist>
                 {
@@ -115,9 +112,7 @@ FreeText.propTypes = {
   handleValidation: PropTypes.func.isRequired,
   activateSaveButton: PropTypes.func.isRequired,
   fields: PropTypes.object.isRequired,
-  allConfigurations: PropTypes.shape({
-    drugDispensingUnits: PropTypes.array,
-  }),
+  options: PropTypes.object,
   handleCancel: PropTypes.func.isRequired,
   handleChange: PropTypes.func.isRequired,
   handleSubmit: PropTypes.func.isRequired,
@@ -127,7 +122,7 @@ FreeText.propTypes = {
 };
 
 FreeText.defaultProps = {
-  allConfigurations: {},
+  options: {},
 };
 
 export default FreeText;

--- a/app/js/components/orderEntry/addForm/StandardDose.jsx
+++ b/app/js/components/orderEntry/addForm/StandardDose.jsx
@@ -6,7 +6,7 @@ const StandardDose = ({
   fields,
   fieldErrors,
   careSetting,
-  allConfigurations,
+  options,
   handleChange,
   handleValidation,
   activateSaveButton,
@@ -14,8 +14,8 @@ const StandardDose = ({
   handleCancel,
 }) => {
   const {
-    drugDosingUnits, orderFrequencies, drugRoutes, durationUnits, drugDispensingUnits,
-  } = allConfigurations;
+    dosingUnit, frequency, route, durationUnit, dispensingUnit,
+  } = options;
   return (
     <div>
       <form className="simple-form-ui">
@@ -54,12 +54,11 @@ const StandardDose = ({
                 required />
               <datalist id="dosingUnits" >
                 {
-                  drugDosingUnits
-                && drugDosingUnits.map(unit => (
-                  <option
-                    key={unit.uuid}
-                    value={unit.display}
-                  />))
+                  dosingUnit && dosingUnit.map(unit => (
+                    <option
+                      key={unit.uuid}
+                      value={unit.display}
+                    />))
                 }
               </datalist>
               {
@@ -81,13 +80,12 @@ const StandardDose = ({
                 onChange={handleChange} />
               <datalist id="orderFrequencies" >
                 {
-                  orderFrequencies &&
-                orderFrequencies.map(frequency => (
-                  <option
-                    key={frequency.uuid}
-                    value={frequency.display}
-                  />
-                ))
+                  frequency && frequency.map(frequencyOption => (
+                    <option
+                      key={frequencyOption.uuid}
+                      value={frequencyOption.display}
+                    />
+                  ))
                 }
               </datalist>
               {
@@ -109,12 +107,11 @@ const StandardDose = ({
                 onChange={handleChange} />
               <datalist id="routes" >
                 {
-                  drugRoutes &&
-                drugRoutes.map(route => (
-                  <option
-                    key={route.uuid}
-                    value={route.display}
-                  />))
+                  route && route.map(routeOption => (
+                    <option
+                      key={routeOption.uuid}
+                      value={routeOption.display}
+                    />))
                 }
               </datalist>
               {
@@ -171,13 +168,12 @@ const StandardDose = ({
                 onChange={handleChange} />
               <datalist id="durationUnits" >
                 {
-                  durationUnits &&
-                durationUnits.map(unit => (
-                  <option
-                    key={unit.uuid}
-                    value={unit.display}
-                  />
-                ))
+                  durationUnit && durationUnit.map(unit => (
+                    <option
+                      key={unit.uuid}
+                      value={unit.display}
+                    />
+                  ))
                 }
               </datalist>
               {
@@ -240,12 +236,11 @@ const StandardDose = ({
                   onChange={handleChange} />
                 <datalist id="dispensingUnits" >
                   {
-                    drugDispensingUnits &&
-                  drugDispensingUnits.map(unit => (
-                    <option
-                      key={unit.uuid}
-                      value={unit.display}
-                    />))
+                    dispensingUnit && dispensingUnit.map(unit => (
+                      <option
+                        key={unit.uuid}
+                        value={unit.display}
+                      />))
                   }
                 </datalist>
                 {
@@ -287,7 +282,7 @@ StandardDose.propTypes = {
   fields: PropTypes.object.isRequired,
   fieldErrors: PropTypes.object.isRequired,
   careSetting: PropTypes.object.isRequired,
-  allConfigurations: PropTypes.object.isRequired,
+  options: PropTypes.object.isRequired,
   handleChange: PropTypes.func.isRequired,
   handleValidation: PropTypes.func.isRequired,
   activateSaveButton: PropTypes.func.isRequired,

--- a/tests/components/orderentry/addForm/AddForm.test.jsx
+++ b/tests/components/orderentry/addForm/AddForm.test.jsx
@@ -55,6 +55,14 @@ describe('Test for adding a new drug order', () => {
       it('should not have any errors messages initially', () => {
         expect(wrapper.find('span.field-error').length).toBe(0);
       });
+      it('should not have options initially', () => {
+        expect(wrapper.find('option')).toHaveLength(0);
+      });
+      it('should have options once a user inputs a unit that corresponds to configurations', () => {
+        wrapper.find('[name="dosingUnit"]').simulate('change', {target: {name: 'dosingUnit', value: 'g'}});
+        expect(wrapper.find('option')).toHaveLength(1);
+
+      });
       describe('Activate and deactivate Confirm button', () => {
         beforeEach(() => {
           wrapper.find('[name="dose"]').simulate('change', {target: {name: 'dose', value: 8}});

--- a/tests/components/orderentry/addForm/FreeText.test.jsx
+++ b/tests/components/orderentry/addForm/FreeText.test.jsx
@@ -5,12 +5,23 @@ import FreeText from '../../../../app/js/components/orderEntry/addForm/FreeText'
 const props = {
   activateSaveButton: jest.fn(),
   fields: {},
-  careSetting: {}
+  fieldErrors: {},
+  careSetting: {display: 'Outpatient'},
+  options: {
+    dispensingUnit: [{
+      display: 'kits',
+      uuid: 'ABC-56Y',
+    }]
+  }
 };
 
 describe('Test for Free text form', () => {
   it('should render component', () => {
     const wrapper = shallow(<FreeText {...props} />  );
     expect(wrapper).toMatchSnapshot()
+  });
+  it('should render options if they exist in state', () => {
+    const wrapper = shallow(<FreeText {...props} />  );
+    expect(wrapper.find('option')).toHaveLength(1);
   });
 });

--- a/tests/components/orderentry/addForm/StandardDose.test.jsx
+++ b/tests/components/orderentry/addForm/StandardDose.test.jsx
@@ -6,7 +6,24 @@ const inpatientProps = {
   fields: {},
   fieldErrors: {},
   careSetting: {display: 'Inpatient'},
-  allConfigurations: {},
+  options: {
+    dosingUnit: [{
+      display: 'milligrams',
+      uuid: 'ABC-56Y',
+    }],
+    frequency: [{
+      display: 'once',
+      uuid: 'ABC-56Y',
+    }],
+    route: [{
+      display: 'oral',
+      uuid: 'ABC-56Y',
+    }],
+    durationUnit: [{
+      display: 'weeks',
+      uuid: 'ABC-56Y',
+    }]
+  },
   handleChange: jest.fn(),
   handleValidation: jest.fn(),
   activateSaveButton: jest.fn(),
@@ -41,6 +58,9 @@ describe('Test for Standard dose form', () => {
     });
     it('form should contain a cancel button', () => {
       expect(wrapper.find('button.cancel').length).toBe(1);
+    });
+    it('should render options if they exist in state', () => {
+      expect(wrapper.find('option')).toHaveLength(4);
     });
     it('inpatient caresetting should not render dispense fields but outpatient should', () => {
       const outpatientWrapper = shallow(<StandardDose {...outpatientProps} />);


### PR DESCRIPTION
### JIRA TICKET NAME 
[OEUI-117: Drop downs options should only be filtered by the first letter](https://issues.openmrs.org/browse/OEUI-117)

## Summary:
Currently on the dropdowns in the Order Entry UI when the user types any letter or combination of letters in any of combo boxes, the choices are filtered based on those letters appearing anywhere in the choices.    It would be better if the results were filtered based on those letters appearing in the beginning of the choices.  e.g. if a user types "ta" in the units box, they probably want tablet or tablespoon, but not container.   