### PR TITLE
OEUI-132: Past orders date should be dateActivated - dateStopped or autoExpireDate

### DIFF
--- a/__mocks__/mockData.js
+++ b/__mocks__/mockData.js
@@ -155,6 +155,7 @@ export default {
   },
   drug: {},
   auditInfo: {},
+  dateActivated: '',
   order: {
     uuid: '',
     drugName: { drug: { display: '' } },

--- a/app/js/components/orderEntry/PastOrder.jsx
+++ b/app/js/components/orderEntry/PastOrder.jsx
@@ -4,9 +4,9 @@ import PropTypes from 'prop-types';
 
 export const PastOrder = (props) => {
   const {
-    drug, dosingType, action, auditInfo, dose, doseUnits, frequency,
+    drug, dosingType, action, dose, doseUnits, frequency,
     route, duration, durationUnits, dosingInstructions,
-    quantityUnits, autoExpireDate, quantity, dateFormat,
+    quantityUnits, dateStopped, autoExpireDate, quantity, dateActivated, dateFormat,
   } = props;
 
   let details;
@@ -37,8 +37,8 @@ export const PastOrder = (props) => {
   return (
     <tr>
       <td>
-        {format(auditInfo.dateCreated, dateFormat)} {autoExpireDate &&
-           `- ${format(autoExpireDate, dateFormat)}`}
+        {format(dateActivated, dateFormat)}
+        {(dateStopped || autoExpireDate) && `- ${format((dateStopped || autoExpireDate), dateFormat)}`}
       </td>
       <td>
         {details}
@@ -50,7 +50,6 @@ export const PastOrder = (props) => {
 PastOrder.propTypes = {
   drug: PropTypes.shape({}).isRequired,
   action: PropTypes.string.isRequired,
-  auditInfo: PropTypes.shape({}).isRequired,
   dateFormat: PropTypes.string.isRequired,
   dosingType: PropTypes.string,
   dose: PropTypes.number,
@@ -62,6 +61,8 @@ PastOrder.propTypes = {
   dosingInstructions: PropTypes.string,
   quantityUnits: PropTypes.shape({}),
   autoExpireDate: PropTypes.string,
+  dateActivated: PropTypes.string,
+  dateStopped: PropTypes.string,
   quantity: PropTypes.number,
 };
 
@@ -76,6 +77,8 @@ PastOrder.defaultProps = {
   dosingInstructions: '',
   quantityUnits: null,
   autoExpireDate: '',
+  dateActivated: '',
+  dateStopped: '',
   quantity: null,
 };
 

--- a/tests/components/orderentry/PastOrder.test.jsx
+++ b/tests/components/orderentry/PastOrder.test.jsx
@@ -1,15 +1,41 @@
 import React from 'react';
 import PastOrder from '../../../app/js/components/orderEntry/PastOrder';
 
-const { drug, auditInfo } = mockData;
+const { drug, dateActivated } = mockData;
 const props = {
-    drug,
-    auditInfo,
+  dosingType: 'org.openmrs.SimpleDosingInstructions',
+  drug: { display: 'new drug' },
+  doseUnits: { display: 'drops' },
+  frequency: { display: 'twice a week' },
+  route: { display: 'reactally' },
+  quantityUnits: { display: 'drops' },
+  durationUnits: { display: 'weeks' },
+  dateActivated: '2018-May-20 10:59',
+  dateStopped: '2018-May-20 10:59',
+  autoExpireDate: '2018-May-20 10:59',
 }
 
 describe('<PastOrder />', () => {
-    it('should render component', () => {
-        const wrapper = shallow(<PastOrder {...props}/>);
-        expect(wrapper).toMatchSnapshot()
-    });
+  it('should render component', () => {
+    const wrapper = shallow(<PastOrder {...props}/>);
+    expect(wrapper).toMatchSnapshot()
   });
+
+  it('should render details', () => {
+    const props = {
+      dosingType: '',
+      drug: { display: 'new drug' },
+      doseUnits: { display: 'drops' },
+      frequency: { display: 'twice a week' },
+      route: { display: 'reactally' },
+      quantityUnits: { display: 'drops' },
+      durationUnits: { display: 'weeks' },
+      dateActivated: '2018-May-20 10:59',
+      dateStopped: '2018-May-20 10:59',
+      autoExpireDate: '2018-May-20 10:59',
+    }
+
+    const wrapper = shallow(<PastOrder {...props} />);
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/tests/components/orderentry/PastOrders.test.jsx
+++ b/tests/components/orderentry/PastOrders.test.jsx
@@ -18,7 +18,7 @@ const props={
       dose:1,
       quantity:2,
       duration:2,
-      auditInfo:{dateCreated:'2018-03-20 10:59:22'},
+      dateActivated:'2018-May-20 10:59',
       drug:{display:'new drug'},
       doseUnits:{display:'drops'},
       frequency:{display:'twice a week'},


### PR DESCRIPTION
## JIRA TICKET NAME

[OEUI-132:  Past orders date should be dateActivated - dateStopped or autoExpireDate](https://issues.openmrs.org/browse/OEUI-132)

## SUMMARY:
In the current implementation, discontinuing an active order places the order under past order with date in the format `dateCreated - autoExpireDate`. The date should be in the date format `dateActivated - dateStopped or autoExpireDate`. 