### PR TITLE
OEUI-139: Widen the date column to occupy only two row spans in Active and Past order tables

### DIFF
--- a/app/css/openmrs-owa-orderentry.css
+++ b/app/css/openmrs-owa-orderentry.css
@@ -91,8 +91,8 @@ body {
     min-width: 958px;
 }
 
-.w-145-px {
-    width: 145px;
+.w-155-px {
+    width: 155px;
 }
 
 .w-81-px {

--- a/app/js/components/orderEntry/ActiveOrders.jsx
+++ b/app/js/components/orderEntry/ActiveOrders.jsx
@@ -223,7 +223,7 @@ export class ActiveOrders extends React.Component {
         <table className="table bordered mw-958-px">
           <thead>
             <tr>
-              <th className="w-145-px">Date</th>
+              <th className="w-155-px">Date</th>
               <th>Details</th>
               <th className="w-81-px">Actions</th>
             </tr>

--- a/app/js/components/orderEntry/PastOrders.jsx
+++ b/app/js/components/orderEntry/PastOrders.jsx
@@ -68,7 +68,7 @@ export class PastOrders extends React.Component {
             <table className="table bordered mw-958-px">
               <thead>
                 <tr>
-                  <th className="w-145-px">Date</th>
+                  <th className="w-155-px">Date</th>
                   <th>Details</th>
                 </tr>
               </thead>


### PR DESCRIPTION
## JIRA TICKET NAME:
[OEUI-139: Widen the date column to occupy only two row spans in Active and Past order tables](https://issues.openmrs.org/browse/OEUI-139)
### SUMMARY:
In some instances, the dateStarted and dateStopped span three rows which is inconsistent. These dates should span only two columns.