### PR TITLE
OEUI-131: Use a constant for the date format (Bug Fix)

### DIFF
--- a/app/js/components/orderEntry/OrderEntryPage.jsx
+++ b/app/js/components/orderEntry/OrderEntryPage.jsx
@@ -101,10 +101,10 @@ export class OrderEntryPage extends React.Component {
                 </span> :
                 <span>
                   ensure that you have created a setting called
-                  <strong>orderentryowa.dateAndTimeFormat</strong>
+                  <strong> orderentryowa.dateAndTimeFormat</strong>
                   &nbsp;
                   with a corresponding value of the date format,
-                   e.g. <strong>DD-MM-YYYY HH:mm</strong>.
+                   e.g. <strong>DD-MMM-YYYY HH:mm</strong>.
                 </span>
             }
           </p>


### PR DESCRIPTION
[OEUI-131: Use a constant for the date format](https://issues.openmrs.org/browse/OEUI-131)

### SUMMARY: 
The date format that is sampled in the error message, when no global property has been added is currently incorrect. This PR fixes that, to show the correct intended date format.