### PR TITLE
OEUI-160: Add default dateTime format in app

### DIFF
--- a/app/js/actions/dateFormat.js
+++ b/app/js/actions/dateFormat.js
@@ -17,11 +17,14 @@ export const getDateFormatFailure = error => ({
 export const getDateFormat = value => dispatch =>
   axiosInstance.get(`systemsetting?v=${value}&q=orderentryowa.dateAndTimeFormat`)
     .then(({ data: { results } }) => {
-      if (results.length > 0 && results[0].value === null) {
-        throw Error("incomplete config");
+      if (!results.length) {
+        const DATE_FORMAT = 'DD-MMM-YYYY HH:mm';
+        dispatch(getDateFormatSuccess(DATE_FORMAT));
+      } else if (results.length && results[0].value === null) {
+        throw Error('incomplete config');
+      } else {
+        dispatch(getDateFormatSuccess(results[0].value));
       }
-
-      dispatch(getDateFormatSuccess(results[0].value));
     })
     .catch((error) => {
       dispatch(getDateFormatFailure(error.message));

--- a/app/js/components/orderEntry/OrderEntryPage.jsx
+++ b/app/js/components/orderEntry/OrderEntryPage.jsx
@@ -89,24 +89,14 @@ export class OrderEntryPage extends React.Component {
       return (
         <div className="error-notice">
           <p>
-            Configuration for <strong>orderentryowa.dateAndTimeFormat</strong> {dateError === 'incomplete config' ? 'is incomplete' : 'does not exist'}.
-            Please contact your administrator for more information.
+            Configuration for <strong>orderentryowa.dateAndTimeFormat</strong> is incomplete.
           </p>
           <p>
             As an Administrator,&nbsp;
-            {
-              dateError === 'incomplete config' ?
-                <span>
-                  please ensure that you have created a valid <strong>date and time format</strong>.
-                </span> :
-                <span>
-                  ensure that you have created a setting called
-                  <strong> orderentryowa.dateAndTimeFormat</strong>
-                  &nbsp;
-                  with a corresponding value of the date format,
-                   e.g. <strong>DD-MMM-YYYY HH:mm</strong>.
-                </span>
-            }
+            <span>
+              please ensure that you have created a valid <strong>date and time format</strong>,
+              with a corresponding value, for example: <strong>DD-MMM-YYYY HH:mm</strong>.
+            </span>
           </p>
         </div>
       );

--- a/tests/actions/dateFormat.test.js
+++ b/tests/actions/dateFormat.test.js
@@ -48,6 +48,27 @@ describe('Get date and time format actions', () => {
     done();
   });
 
+  it('should dispatch a default date and time format successfuly', async (done) => {
+    moxios.stubRequest(`${apiBaseUrl}/systemsetting?v=${value}&q=orderentryowa.dateAndTimeFormat`, {
+      status: 200,
+      response: {
+        results: []
+      }
+    });
+
+    const expectedActions = {
+      GET_DATE_SUCCESS,
+      dateFormat: 'DD-MMM-YYYY HH:mm',
+    }
+
+    const store = mockStore({});
+
+    await store.dispatch(getDateFormat(value), () => {
+      expect(store.getActions()).toEqual(expectedActions);
+    });
+    done();
+  });
+
   it('should dispatch getting date and time format successfuly with empty value', async (done) => {
     moxios.stubRequest(`${apiBaseUrl}/systemsetting?v=${value}&q=orderentryowa.dateAndTimeFormat`, {
       status: 200,


### PR DESCRIPTION
[OEUI-160: Use a constant for the date format](https://issues.openmrs.org/browse/OEUI-160)

### SUMMARY: 
Currently, the app solely relies on the dateTime from the global config variable which results in an error if this is not already set in the app.
This PR adds a constant "DD-MMM-YYYY HH:mm" dateTime format as fallback incase the global dateTime is not configured.