### PR TITLE
OEUI-162: Fix bug in standard/free text drug mode switch

### DIFF
--- a/app/js/components/orderEntry/addForm/AddForm.jsx
+++ b/app/js/components/orderEntry/addForm/AddForm.jsx
@@ -61,6 +61,7 @@ export class AddForm extends React.Component {
   handleFormTabs = (tabIndex) => {
     this.setState({
       activeTabIndex: tabIndex,
+      fieldErrors: {},
     });
   }
 


### PR DESCRIPTION
# **JIRA TICKET NAME:**

[OEUI-162: Fix bug in standard/free text drug mode switch](https://issues.openmrs.org/browse/OEUI-162)

## **SUMMARY:**

This ticket fixes the bug that occurs when a user switches between to the free text drug entry mode from the standard mode causing the "Add" button to be disabled.

NOTE: This happens when the user has an error on some of the fields in the standard mode and switches to the free text mode. See image below