### PR TITLE
OEUI-163: Make dateTimeFormat key consistent with others

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ Before using the Order Entry Open Web Application, the administrator should make
 2. Create a setting `order.encounterType` whose value should correspond to the name given to the Encounter Type created above.
 3. Create an Encounter Role called `Clinician` or any other name.
 4. Create a setting `order.encounterRole` whose value should correspond to the name given to the encounter role created in 3 above.
-5. Create a date format, setting `orderentryowa.dateAndTimeFormat` as the name, with a value of the date format, e.g. `DD-MMM-YYYY HH:mm`, in the global properties
+5. Create a date format, setting `order.dateTimeFormat` as the name, with a value of the date format, e.g. `DD-MMM-YYYY HH:mm`, in the global properties
 
 **NB:** Not having any of the above configurations will result into an error notice. Please check more information [here](https://wiki.openmrs.org/display/projects/Order+Entry+UI+Administrator+Guide)
 

--- a/app/js/actions/dateFormat.js
+++ b/app/js/actions/dateFormat.js
@@ -15,7 +15,7 @@ export const getDateFormatFailure = error => ({
 });
 
 export const getDateFormat = value => dispatch =>
-  axiosInstance.get(`systemsetting?v=${value}&q=orderentryowa.dateAndTimeFormat`)
+  axiosInstance.get(`systemsetting?v=${value}&q=order.dateTimeFormat`)
     .then(({ data: { results } }) => {
       if (!results.length) {
         const DATE_FORMAT = 'DD-MMM-YYYY HH:mm';

--- a/app/js/components/orderEntry/OrderEntryPage.jsx
+++ b/app/js/components/orderEntry/OrderEntryPage.jsx
@@ -108,7 +108,7 @@ export class OrderEntryPage extends React.Component {
       return (
         <div className="error-notice">
           <p>
-            Configuration for <strong>orderentryowa.dateAndTimeFormat</strong> is incomplete.
+            Configuration for <strong>order.dateTimeFormat</strong> is incomplete.
           </p>
           <p>
             As an Administrator,&nbsp;

--- a/tests/actions/dateFormat.test.js
+++ b/tests/actions/dateFormat.test.js
@@ -23,7 +23,7 @@ describe('Get date and time format actions', () => {
   const value = 'default';
 
   it('should dispatch getting date and time format successfuly', async (done) => {
-    moxios.stubRequest(`${apiBaseUrl}/systemsetting?v=${value}&q=orderentryowa.dateAndTimeFormat`, {
+    moxios.stubRequest(`${apiBaseUrl}/systemsetting?v=${value}&q=order.dateTimeFormat`, {
       status: 200,
       response: {
         results: [
@@ -49,7 +49,7 @@ describe('Get date and time format actions', () => {
   });
 
   it('should dispatch a default date and time format successfuly', async (done) => {
-    moxios.stubRequest(`${apiBaseUrl}/systemsetting?v=${value}&q=orderentryowa.dateAndTimeFormat`, {
+    moxios.stubRequest(`${apiBaseUrl}/systemsetting?v=${value}&q=order.dateTimeFormat`, {
       status: 200,
       response: {
         results: []
@@ -70,7 +70,7 @@ describe('Get date and time format actions', () => {
   });
 
   it('should dispatch getting date and time format successfuly with empty value', async (done) => {
-    moxios.stubRequest(`${apiBaseUrl}/systemsetting?v=${value}&q=orderentryowa.dateAndTimeFormat`, {
+    moxios.stubRequest(`${apiBaseUrl}/systemsetting?v=${value}&q=order.dateTimeFormat`, {
       status: 200,
       response: {
         results: [
@@ -97,7 +97,7 @@ describe('Get date and time format actions', () => {
   });
 
   it('should throw an error when given an empty value', async (done) => {
-    moxios.stubRequest(`${apiBaseUrl}/systemsetting?v=${value}&q=orderentryowa.dateAndTimeFormat`, {
+    moxios.stubRequest(`${apiBaseUrl}/systemsetting?v=${value}&q=order.dateTimeFormat`, {
       status: 200,
       response: {
         results: [
@@ -118,7 +118,7 @@ describe('Get date and time format actions', () => {
   });
 
   it('should dispatch error when gettig fate and time format fails', async (done) => {
-    moxios.stubRequest(`${apiBaseUrl}/systemsetting?v=${value}&q=orderentryowa.dateAndTimeFormat`, {
+    moxios.stubRequest(`${apiBaseUrl}/systemsetting?v=${value}&q=order.dateTimeFormat`, {
       status: 401,
       error: {
         message: "User not logged in"

--- a/tests/components/orderentry/OrderEntryPage.test.jsx
+++ b/tests/components/orderentry/OrderEntryPage.test.jsx
@@ -174,7 +174,7 @@ describe('Test for Order entry page when order.encounterRole is not set', () => 
   });
 });
 
-describe('Test for Order entry page when orderentryowa.dateAndTimeFormat is set', () => {
+describe('Test for Order entry page when order.dateTimeFormat is set', () => {
   beforeEach(() => {
     props = {
       fetchPatientCareSetting: jest.fn(),


### PR DESCRIPTION
## **JIRA TICKET NAME:**
[OEUI-163: Make dateTimeFormat key consistent with others](https://issues.openmrs.org/browse/OEUI-163)

### SUMMARY:
The global property key for setting up date and Time is orderentryowa.dateAndTimeFormat which is not consistent with the other global properties e.g order.encounterType.

This ticket is to fix this inconsistency by changing the dateTime key to order.dateTimeFormat