### PR TITLE
OEUI-171: Make component snapshots readable

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -16,6 +16,9 @@ module.exports = {
   setupFiles: [
     '<rootDir>/tests/setup.js'
   ],
+  snapshotSerializers: [
+    "enzyme-to-json/serializer"
+  ],
   moduleFileExtensions: [
     'js',
     'jsx'


### PR DESCRIPTION
### JIRA TICKET NAME
[OEUI-171: Make component snapshots readable](https://issues.openmrs.org/browse/OEUI-171)

### SUMMARY
The snapshots generated from the snapshot tests are not readable and this makes it difficult to know if the snapshot generated is actually what is expected(the real essence of the snapshot). This Pull Request adds a serializer that ensures that the snapshots are readable.