### PR TITLE
OEUI-200: Render Test Panels dynamically

### DIFF
--- a/app/js/components/labOrderEntry/LabEntryForm.jsx
+++ b/app/js/components/labOrderEntry/LabEntryForm.jsx
@@ -53,6 +53,7 @@ export class LabEntryForm extends PureComponent {
       uuid: PropTypes.string,
     }),
     conceptsAsTests: PropTypes.array,
+    conceptsAsPanels: PropTypes.array,
     session: PropTypes.shape({
       currentProvider: PropTypes.shape({
         person: PropTypes.shape({
@@ -80,6 +81,7 @@ export class LabEntryForm extends PureComponent {
       uuid: '',
     },
     conceptsAsTests: [],
+    conceptsAsPanels: [],
     session: {
       currentProvider: {
         person: {
@@ -177,6 +179,7 @@ export class LabEntryForm extends PureComponent {
     <div>
       <LabPanelFieldSet
         handleTestSelection={this.handleTestSelection}
+        panels={this.props.conceptsAsPanels}
         selectedPanelIds={this.state.selectedPanelIds}
       />
       <LabTestFieldSet
@@ -321,6 +324,7 @@ export const mapStateToProps = ({
   dateFormatReducer: { dateFormat },
   labConceptsReducer: {
     conceptsAsTests,
+    conceptsAsPanels,
   },
   openmrs: { session },
   fetchLabOrderReducer: { labOrders },
@@ -334,6 +338,7 @@ export const mapStateToProps = ({
   draftLabOrders,
   dateFormat,
   conceptsAsTests,
+  conceptsAsPanels,
   selectedLabPanels,
   defaultTests,
   selectedTests,

--- a/app/js/components/labOrderEntry/LabPanelFieldSet.jsx
+++ b/app/js/components/labOrderEntry/LabPanelFieldSet.jsx
@@ -1,21 +1,31 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { panelData } from './labData';
 import '../../../css/grid.scss';
 
-const LabPanelFieldSet = ({ selectedPanelIds, handleTestSelection }) => (
+
+const formatPanelName = (panelName) => {
+  const name = panelName;
+  return name.replace(/panel/i, '').trim();
+};
+
+const LabPanelFieldSet = ({ selectedPanelIds, handleTestSelection, panels }) => (
   <fieldset className="fieldset">
     <legend>Panels</legend>
-    {panelData.map(panel => (
-      <button
-        id="panel-button"
-        className={selectedPanelIds.includes(panel.id) ? 'active lab-tests-btn' : 'lab-tests-btn'}
-        type="button"
-        key={`${panel.id}`}
-        onClick={() => handleTestSelection(panel, 'panel')}>
-        {panel.name}
-      </button>
-    ))}
+    <div className="panel-box">
+      {
+        panels.map(panel => (
+          <button
+            id="panel-button"
+            className={(selectedPanelIds.includes(panel.uuid)) ? 'active lab-tests-btn' : 'lab-tests-btn'}
+            type="button"
+            key={`${panel.uuid}`}
+            onClick={() => handleTestSelection(panel, 'panel')}
+          >
+            {formatPanelName(panel.display.toLowerCase())}
+          </button>
+        ))
+      }
+    </div>
   </fieldset>
 );
 
@@ -25,6 +35,7 @@ LabPanelFieldSet.defaultProps = {
 
 LabPanelFieldSet.propTypes = {
   handleTestSelection: PropTypes.func.isRequired,
+  panels: PropTypes.array.isRequired,
   selectedPanelIds: PropTypes.array,
 };
 

--- a/app/js/components/labOrderEntry/styles.scss
+++ b/app/js/components/labOrderEntry/styles.scss
@@ -83,6 +83,7 @@
 
   .fieldset{
     margin-bottom: 10px;
+    min-width: 92%;
   }
 
   .panel-box, .tests-box{
@@ -90,11 +91,11 @@
     flex-wrap: wrap;
   }
 
-  .lab-tests-btn {	  
+  .lab-tests-btn{
     width: 145px;
-    font-size: 13px;
+    font-size: 12px;
     font-weight: bold;
-    margin-right: 10px;
+    margin-right: 10px;	    
     margin-bottom: 10px;
     flex-basis: 31.7%;
     text-transform: capitalize;

--- a/app/js/reducers/initialState.js
+++ b/app/js/reducers/initialState.js
@@ -122,5 +122,6 @@ export default {
     loading: false,
     concepts: [],
     conceptsAsTests: [],
+    conceptsAsPanels: [],
   },
 };

--- a/app/js/reducers/labOrders/labConceptsReducer.js
+++ b/app/js/reducers/labOrders/labConceptsReducer.js
@@ -31,6 +31,7 @@ export default (state = initialState.labConcepts, action) => {
         ...state,
         concepts,
         conceptsAsTests: removeDuplicateTests(allTests),
+        conceptsAsPanels: panels,
         loading: false,
         error: null,
       };

--- a/tests/components/labOrderEntry/LabEntryForm.test.jsx
+++ b/tests/components/labOrderEntry/LabEntryForm.test.jsx
@@ -60,6 +60,7 @@ props = {
     uuid: 'jfgfhfgf',
   },
   conceptsAsTests: [],
+  conceptsAsPanels: [],
   encounterType: {
     uuid: 'fhhfgfh9998',
   },
@@ -105,7 +106,7 @@ describe('Component: LabEntryForm', () => {
       dateFormatReducer: { dateFormat: 'DD-MM-YYYY HH:mm' },
       patientReducer: { patient: {} },
       fetchLabOrderReducer: { labOrders: [] },
-      labConceptsReducer: { conceptsAsTests:[] },
+      labConceptsReducer: { conceptsAsTests:[], conceptsAsPanels:[] },
       openmrs: { session: {} },
       encounterRoleReducer: { encounterRole: {} },
       encounterReducer: { encounterType: {} },

--- a/tests/components/labOrderEntry/LabPanelFieldSet.test.jsx
+++ b/tests/components/labOrderEntry/LabPanelFieldSet.test.jsx
@@ -3,10 +3,6 @@ import LabPanelFieldSet from '../../../app/js/components/labOrderEntry/LabPanelF
 
 let props;
 let mountedComponent;
-props = {
-  handleTestSelection: jest.fn(),
-  selectedPanelIds: [1, 2],
-};
 
 const getComponent = () => {
   if (!mountedComponent) {
@@ -18,6 +14,14 @@ const getComponent = () => {
 describe('Component: LabPanelFieldSet', () => {
   beforeEach(() => {
     mountedComponent = undefined;
+    props = {
+      handleTestSelection: jest.fn(),
+      selectedPanelIds: [],
+      panels: [{
+        uuid: 'asampleduuid1234',
+        display: 'sample'
+      }]
+    };
   });
 
   it('should mount initially', () => {
@@ -31,5 +35,12 @@ describe('Component: LabPanelFieldSet', () => {
     const panelButton = component.find('#panel-button').at(0); // click the second button
     panelButton.simulate('click', {});
     expect(handleTestSelection).toBeCalled();
+  });
+
+  it('should add class `active` to the slected panels', () => {
+    props.selectedPanelIds = ['asampleduuid1234'];
+    const component = getComponent();
+    const activePanelButton = component.find('.active.lab-tests-btn');
+    expect(activePanelButton.length).toEqual(1);
   });
 });

--- a/tests/reducers/labOrderReducers/labConceptsReducer.test.js
+++ b/tests/reducers/labOrderReducers/labConceptsReducer.test.js
@@ -9,6 +9,7 @@ import labConceptsReducer from '../../../app/js/reducers/labOrders/labConceptsRe
 const mockConcepts = [
   { uuid: '123Abc-456', name: 'Concept A', set: false },
   {
+    uuid: '888ya-kkk',
     name: 'Concept B',
     set: true,
     setMembers: [
@@ -44,6 +45,18 @@ describe('Lab Concepts reducer', () => {
         { uuid: '138Abc-466', name: 'Concept E', set: false  },
         { uuid: '123Def-456', name: 'Concept F', set: false  },
       ],
+      conceptsAsPanels: [
+        {
+          uuid: '888ya-kkk',
+          name: 'Concept B',
+          set: true,
+          setMembers: [
+            { uuid: '456Abc-123', name: 'Concept D', set: false },
+            { uuid: '138Abc-466', name: 'Concept E', set: false  },
+            { uuid: '123Def-456', name: 'Concept F', set: false  },
+          ]
+        }
+      ]
     };
     const actualState = labConceptsReducer(initialState.labConcepts, mockAction);
     expect(actualState).toEqual(expectedState);
@@ -57,6 +70,7 @@ describe('Lab Concepts reducer', () => {
       loading: true,
       concepts: [],
       conceptsAsTests: [],
+      conceptsAsPanels: [],
     };
     const actualState = labConceptsReducer(initialState.labConcepts, mockAction);
     expect(actualState).toEqual(expectedState);
@@ -74,6 +88,7 @@ describe('Lab Concepts reducer', () => {
       loading: false,
       concepts: [],
       conceptsAsTests: [],
+      conceptsAsPanels: [],
     };
     const actualState = labConceptsReducer(initialState.labConcepts, mockAction);
     expect(actualState).toEqual(expectedState);


### PR DESCRIPTION
### JIRA TICKET NAME
[OEUI-200: Render the concepts of type LabSet as the panels belonging to a Lab Category](https://issues.openmrs.org/browse/OEUI-200)

### SUMMARY
This Pull Request renders the Test Panels dynamically with the data gotten from the database replacing the mock data used previously.  

**NOTE:** This pull request actually breaks the functionality of adding panels to draft and that is because of the change in the data model. However, this issue would be fixed in this [JIRA TICKET](https://issues.openmrs.org/browse/OEUI-212)