### PR TITLE
OEUI-210: Replace Moment.js with Date-fns.js

### DIFF
--- a/app/js/components/labOrderEntry/LabEntryForm.jsx
+++ b/app/js/components/labOrderEntry/LabEntryForm.jsx
@@ -31,6 +31,7 @@ export class LabEntryForm extends PureComponent {
       labOrderData: PropTypes.object,
     }),
     draftLabOrders: PropTypes.arrayOf(PropTypes.any).isRequired,
+    dateFormat: PropTypes.string.isRequired,
     selectedLabPanels: PropTypes.arrayOf(PropTypes.any).isRequired,
     defaultTests: PropTypes.arrayOf(PropTypes.any).isRequired,
     selectedTests: PropTypes.arrayOf(PropTypes.any).isRequired,
@@ -228,11 +229,11 @@ export class LabEntryForm extends PureComponent {
   };
 
   renderPastOrders = () => {
-    const { results } = this.props.labOrders;
+    const { labOrders: { results }, dateFormat } = this.props;
     if (results.length > 0) {
       return (
         <Accordion open title="Past Lab Orders">
-          <PastOrders orders={results} />
+          <PastOrders orders={results} dateFormat={dateFormat} />
         </Accordion>
       );
     }
@@ -303,6 +304,7 @@ export const mapStateToProps = ({
     defaultTests,
     selectedTests,
   },
+  dateFormatReducer: { dateFormat },
   openmrs: { session },
   fetchLabOrderReducer: { labOrders },
   patientReducer: { patient },
@@ -313,6 +315,7 @@ export const mapStateToProps = ({
   labOrderableReducer: { orderables },
 }) => ({
   draftLabOrders,
+  dateFormat,
   selectedLabPanels,
   defaultTests,
   selectedTests,

--- a/app/js/components/labOrderEntry/PastOrders.jsx
+++ b/app/js/components/labOrderEntry/PastOrders.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import moment from 'moment';
+import format from 'date-fns/format';
 
 const PastOrders = ({
-  orders,
+  orders, dateFormat,
 }) => (
   <div>
     <table className="table bordered mw-958-px">
@@ -16,7 +16,7 @@ const PastOrders = ({
       <tbody>
         {orders.map(order => (
           <tr key={order.uuid}>
-            <td>{moment(order.dateActivated).format('DD MMM YYYY')}</td>
+            <td>{format(order.dateActivated, dateFormat)}</td>
             <td>{order.concept.display}</td>
           </tr>
         ))}
@@ -39,6 +39,7 @@ PastOrders.defaultProps = {
 };
 
 PastOrders.propTypes = {
+  dateFormat: PropTypes.string.isRequired,
   orders: PropTypes.arrayOf(PropTypes.shape({
     date: PropTypes.string,
     type: PropTypes.string,

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "deep-freeze": "0.0.1",
     "eslint-config-airbnb-base": "^12.1.0",
     "lodash": "^4.17.5",
-    "moment": "^2.22.2",
     "prop-types": "^15.6.1",
     "react": "^16.3.1",
     "react-dom": "^16.2.0",

--- a/tests/components/labOrderEntry/LabEntryForm.test.jsx
+++ b/tests/components/labOrderEntry/LabEntryForm.test.jsx
@@ -21,6 +21,7 @@ props = {
     { id: 2, test: 'Hematocrit', concept: '12746hfgjff' },
     { id: 3, test: 'blood', concept: '12746hfgjff' },
   ],
+  dateFormat: 'DD-MM-YYYY HH:mm',
   selectedTests: [
     { id: 1, test: 'Hemoglobin', concept: '12746hfgjff' },
     { id: 2, test: 'Hematocrit', concept: '12746hfgjff' },
@@ -100,6 +101,7 @@ describe('Component: LabEntryForm', () => {
     const component = getComponent();
     mapStateToProps({
       draftLabOrderReducer: { draftLabOrders: {} },
+      dateFormatReducer: { dateFormat: 'DD-MM-YYYY HH:mm' },
       patientReducer: { patient: {} },
       fetchLabOrderReducer: { labOrders: [] },
       openmrs: { session: {} },


### PR DESCRIPTION
### JIRA TICKET NAME
[OEUI-210: Moment vs date-fns](https://issues.openmrs.org/browse/OEUI-210)

### SUMMARY
This Pull Request replaces the use of `Moment.js` date library with `Date-fns.js` in the code base.