### PR TITLE
OEUI-212: Update add/remove to/from draft logic

### DIFF
--- a/app/js/components/labOrderEntry/LabDraftOrder.jsx
+++ b/app/js/components/labOrderEntry/LabDraftOrder.jsx
@@ -28,9 +28,9 @@ export class LabDraftOrder extends PureComponent {
   renderDraftList = () => {
     const { draftLabOrders } = this.props;
     return draftLabOrders.map((order) => {
-      const isPanel = !!order.labCategory;
+      const isPanel = !!order.set;
       const draftType = !isPanel ? 'single' : 'panel';
-      const orderName = isPanel ? order.name : order.test;
+      const orderName = order.display;
       const iconClass = classNames(
         'icon-warning-sign',
         {
@@ -40,7 +40,7 @@ export class LabDraftOrder extends PureComponent {
       );
       return (
         <li className="draft-list small-font" key={shortid.generate()}>
-          <span className="draft-name">{orderName}</span>
+          <span className="draft-name">{orderName.toLowerCase()}</span>
           <div className="action-btn-wrapper">
             <span className="action-btn">
               <a

--- a/app/js/components/labOrderEntry/LabEntryForm.jsx
+++ b/app/js/components/labOrderEntry/LabEntryForm.jsx
@@ -113,8 +113,8 @@ export class LabEntryForm extends PureComponent {
       defaultTests,
     } = nextProps;
     this.setState({
-      selectedPanelIds: selectedLabPanels.map(panel => panel.id),
-      selectedPanelTestIds: defaultTests.map(test => test.id),
+      selectedPanelIds: selectedLabPanels.map(panel => panel.uuid),
+      selectedPanelTestIds: defaultTests.map(test => test.uuid),
     });
   }
 
@@ -147,10 +147,10 @@ export class LabEntryForm extends PureComponent {
         selectedPanelTestIds,
       },
     } = this;
-    const isSelected = !!draftLabOrders.filter(order => order.id === item.id).length;
+    const isSelected = !!draftLabOrders.filter(order => order.uuid === item.uuid).length;
 
     if ((type === 'panel')) {
-      const isSelectedPanel = selectedPanelIds.includes(item.id);
+      const isSelectedPanel = selectedPanelIds.includes(item.uuid);
       if (isSelectedPanel) {
         dispatch(removeTestPanelFromDraft(item));
       } else {
@@ -158,7 +158,7 @@ export class LabEntryForm extends PureComponent {
       }
     }
     if (type === 'single') {
-      const isSelectedPanelTest = selectedPanelTestIds.includes(item.id);
+      const isSelectedPanelTest = selectedPanelTestIds.includes(item.uuid);
       if (!isSelectedPanelTest && isSelected) dispatch(removeTestFromDraft(item));
       if (!isSelectedPanelTest && !isSelected)dispatch(addTestToDraft(item));
     }
@@ -203,7 +203,7 @@ export class LabEntryForm extends PureComponent {
     if (isEmpty) return;
     const orders = draftLabOrders.map(labOrder => (
       {
-        concept: labOrder.concept,
+        concept: labOrder.uuid,
         careSetting: this.props.inpatientCareSetting.uuid,
         encounter: this.props.encounterType.uuid,
         orderer: this.props.session.currentProvider.uuid,

--- a/app/js/components/labOrderEntry/styles.scss
+++ b/app/js/components/labOrderEntry/styles.scss
@@ -147,6 +147,9 @@
         -moz-transition: all 200ms ease-in-out;
       }
     }
+    .draft-name {
+      text-transform: capitalize;
+    }
   }
 
   .stay-right{

--- a/app/js/reducers/draftLabOrderReducer.js
+++ b/app/js/reducers/draftLabOrderReducer.js
@@ -15,8 +15,8 @@ const isValidList = list => (Array.isArray(list) && !!(list.length));
 /* Filters through two lists taking the first as a predicate */
 /* Returns a copy of the first array with all elements of the second array found filtered oout */
 const filterThrough = (from, to) => from.reduce((itemFrom, item) => {
-  const check = to.map(i => i.id).includes(item.id);
-  const filter = check ? itemFrom.filter(i => i.id !== item.id) : itemFrom;
+  const check = to.map(i => i.uuid).includes(item.uuid);
+  const filter = check ? itemFrom.filter(i => i.uuid !== item.uuid) : itemFrom;
   return filter;
 }, from);
 
@@ -24,23 +24,22 @@ export default (state = initialState.draftLabOrderReducer, action) => {
   switch (action.type) {
     case ADD_PANEL_TO_DRAFT_LAB_ORDER: {
       let singleTests = []; /* tests not in panel but in draft anyway */
-      let defaultTests = action.orders.tests; /* all tests in selected panel */
+      let defaultTests = action.orders.setMembers; /* all tests in selected panel */
 
       const hasSingleTests = isValidList(state.singleTests);
       const hasDefaultTests = isValidList(state.defaultTests);
 
-      /* NOTE: what we want is to only add tests if they are in the panel and
-      remove those single test which are also part of a panel */
+      const selectedLabPanels = [...state.selectedLabPanels, action.orders];
 
       if (hasSingleTests && !hasDefaultTests) {
         singleTests = filterThrough(state.draftLabOrders, defaultTests);
       } else if (hasDefaultTests) {
-        singleTests = filterThrough(state.draftLabOrders, [...state.defaultTests, ...defaultTests]);
+        singleTests = filterThrough(
+          state.draftLabOrders,
+          [...state.defaultTests, ...defaultTests, ...selectedLabPanels],
+        );
         defaultTests = [...state.defaultTests, ...defaultTests];
       }
-
-      const selectedLabPanels = [...state.selectedLabPanels, action.orders];
-
       return {
         ...state,
         selectedTests: [...singleTests, ...defaultTests],
@@ -55,8 +54,8 @@ export default (state = initialState.draftLabOrderReducer, action) => {
       let isSelectedTest;
       const hasValues = isValidList(state.defaultTests) && isValidList(state.selectedTests);
       if (hasValues) {
-        isDefaultTest = state.defaultTests.includes(action.order.id);
-        isSelectedTest = state.selectedTests.includes(action.order.id);
+        isDefaultTest = state.defaultTests.includes(action.order.uuid);
+        isSelectedTest = state.selectedTests.includes(action.order.uuid);
         if (isDefaultTest && isSelectedTest) return state;
       }
       return {
@@ -68,9 +67,9 @@ export default (state = initialState.draftLabOrderReducer, action) => {
       };
     }
     case DELETE_TEST_FROM_DRAFT_LAB_ORDER: {
-      const singleTests = state.singleTests.filter(test => test.id !== action.order.id);
-      const selectedTests = state.selectedTests.filter(test => test.id !== action.order.id);
-      const draftLabOrders = state.draftLabOrders.filter(order => order.id !== action.order.id);
+      const singleTests = state.singleTests.filter(test => test.uuid !== action.order.uuid);
+      const selectedTests = state.selectedTests.filter(test => test.uuid !== action.order.uuid);
+      const draftLabOrders = state.draftLabOrders.filter(order => order.uuid !== action.order.uuid);
       return {
         ...state,
         selectedTests,
@@ -110,11 +109,11 @@ export default (state = initialState.draftLabOrderReducer, action) => {
       let defaultTests;
       let selectedLabPanels;
       const draftedPanels = state.selectedLabPanels
-        .filter(panel => panel.id !== action.orders.id);
+        .filter(panel => panel.uuid !== action.orders.uuid);
       const hasValues = isValidList(draftedPanels);
       if (hasValues) {
-        selectedLabPanels = draftedPanels.filter(item => item.id !== action.orders.id);
-        [defaultTests] = selectedLabPanels.map(item => item.tests);
+        selectedLabPanels = draftedPanels.filter(item => item.uuid !== action.orders.uuid);
+        [defaultTests] = selectedLabPanels.map(item => item.setMembers);
         selectedTests = [...state.singleTests, ...defaultTests];
       } else {
         defaultTests = [];

--- a/app/js/reducers/labOrders/labConceptsReducer.js
+++ b/app/js/reducers/labOrders/labConceptsReducer.js
@@ -8,7 +8,7 @@ import initialState from '../initialState';
 
 const removeDuplicateTests = (tests) => {
   const uniqueTestIds = Array.from(new Set(tests.map(test => test.uuid)));
-  const uniqueTests = []; 
+  const uniqueTests = [];
   tests.forEach((test) => {
     const testIndex = uniqueTestIds.indexOf(test.uuid);
     if (testIndex !== -1) {

--- a/tests/components/labOrderEntry/LabDraftOrder.test.jsx
+++ b/tests/components/labOrderEntry/LabDraftOrder.test.jsx
@@ -5,7 +5,7 @@ let props;
 let mountedComponent;
 props = {
   draftLabOrders: [
-    { id: 6, test: 'prothrombin', urgency: 'routine' }
+    { uuid: 6, display: 'prothrombin', urgency: 'routine' }
   ],
   panelTests: [],
   toggleDraftLabOrdersUgency: jest.fn(),

--- a/tests/components/labOrderEntry/LabEntryForm.test.jsx
+++ b/tests/components/labOrderEntry/LabEntryForm.test.jsx
@@ -12,20 +12,20 @@ let mountedComponent;
 
 props = {
   draftLabOrders: [
-    { id: 1, test: 'Hemoglobin', concept: '12746hfgjff' },
-    { id: 2, test: 'Hematocrit', concept: '12746hfgjff' },
-    { id: 3, test: 'blood', concept: '12746hfgjff' },
+    { display: 'Hemoglobin', uuid: '12746hfgjff' },
+    { display: 'Hematocrit', uuid: '12746hfgjff' },
+    { display: 'blood', uuid: '12746hfgjff' },
   ],
   defaultTests: [
-    { id: 1, test: 'Hemoglobin', concept: '12746hfgjff' },
-    { id: 2, test: 'Hematocrit', concept: '12746hfgjff' },
-    { id: 3, test: 'blood', concept: '12746hfgjff' },
+    { display: 'Hemoglobin', uuid: '12746hfgjff' },
+    { display: 'Hematocrit', uuid: '12746hfgjff' },
+    { display: 'blood', uuid: '12746hfgjff' },
   ],
   dateFormat: 'DD-MM-YYYY HH:mm',
   selectedTests: [
-    { id: 1, test: 'Hemoglobin', concept: '12746hfgjff' },
-    { id: 2, test: 'Hematocrit', concept: '12746hfgjff' },
-    { id: 3, test: 'blood', concept: '12746hfgjff' },
+    { display: 'Hemoglobin', uuid: '12746hfgjff' },
+    { display: 'Hematocrit', uuid: '12746hfgjff' },
+    { display: 'blood', uuid: '12746hfgjff' },
   ],
   selectedLabPanels: [panelData[0]],
   dispatch: jest.fn(),
@@ -88,11 +88,16 @@ const getComponent = () => {
   return mountedComponent;
 };
 
-mockPanel = { id: 1, tests: [
-    { id: 4, test: 'liver' },
-    { id: 5, test: 'sickling' },
-    { id: 6, test: 'prothrombin' },
-  ] };
+mockPanel = {
+  uuid: '888ya-kkk',
+  display: 'Concept B',
+  set: true,
+  setMembers: [
+    { uuid: '456Abc-123', name: 'Concept D', set: false },
+    { uuid: '138Abc-466', name: 'Concept E', set: false },
+    { uuid: '123Def-456', name: 'Concept F', set: false },
+  ]
+},
 
 describe('Component: LabEntryForm', () => {
   beforeEach(() => {
@@ -127,7 +132,7 @@ describe('Component: LabEntryForm', () => {
 
   it('should dispatch an action to remove a test panel from the draft', () => {
     const instance = getComponent().instance();
-    instance.state.selectedPanelIds = [1];
+    instance.state.selectedPanelIds = [mockPanel.uuid];
 
     const dipatch = jest.spyOn(props, 'dispatch');
     instance.handleTestSelection(mockPanel, 'panel');

--- a/tests/reducers/draftLabOrderReducer.test.js
+++ b/tests/reducers/draftLabOrderReducer.test.js
@@ -18,15 +18,40 @@ const initialState = {
   singleTests: [],
 };
 
-const mockLabDataPanel = panelData;
-const mockTests = testsData;
-const selectTests = (list, identifier) => list.map((item) =>  item[identifier]); 
+const mockTests = [
+  { uuid: '123Abc-456', name: 'Concept A', set: false },
+  { uuid: '321Abc-146', name: 'Concept C', set: false },
+  { uuid: '456Abc-123', name: 'Concept D', set: false },
+];
+
+const mockPanels = [
+  {
+    uuid: '888ya-kkk',
+    name: 'Concept B',
+    set: true,
+    setMembers: [
+      { uuid: '456Abc-123', name: 'Concept D', set: false },
+      { uuid: '138Abc-466', name: 'Concept E', set: false },
+      { uuid: '123Def-456', name: 'Concept F', set: false },
+    ]
+  },
+  {
+    uuid: '999yar-kkk',
+    name: 'Concept E',
+    set: true,
+    setMembers: [
+      { uuid: '421Abc-123', name: 'Concept G', set: false },
+    ]
+  },
+];
+
+const selectTests = (panel) => panel.map((item) => item[identifier]);
 
 describe('Draft Lab Order Reducer', () => {
   it('should add a panel of tests to draftOrder', () => {
     const action = {
       type: ADD_PANEL_TO_DRAFT_LAB_ORDER,
-      orders: mockLabDataPanel[0],
+      orders: mockPanels[0],
     }
     const newState = draftLabOrderReducer(initialState, action);
     expect(newState.draftLabOrders.length).toEqual(1);
@@ -35,9 +60,9 @@ describe('Draft Lab Order Reducer', () => {
   it('should remove a suite of panel tests when panel is unselected', () => {
     const previousAction = {
       type: ADD_PANEL_TO_DRAFT_LAB_ORDER,
-      orders: mockLabDataPanel[0],
+      orders: mockPanels[0],
     };
-    const nextAction = { ...previousAction, type: DELETE_PANEL_FROM_DRAFT_LAB_ORDER};
+    const nextAction = { ...previousAction, type: DELETE_PANEL_FROM_DRAFT_LAB_ORDER };
     const previousState = draftLabOrderReducer(initialState, previousAction);
     const newState = draftLabOrderReducer(previousState, nextAction);
     expect(newState.draftLabOrders.length).toEqual(0);
@@ -46,15 +71,11 @@ describe('Draft Lab Order Reducer', () => {
   it('should add multiple test panels to the draftOrder', () => {
     const previousAction = {
       type: ADD_PANEL_TO_DRAFT_LAB_ORDER,
-      orders: mockLabDataPanel[0],
+      orders: mockPanels[0],
     };
-    const nextAction = { ...previousAction, orders: mockLabDataPanel[1]};
+    const nextAction = { ...previousAction, orders: mockPanels[1] };
     const previousState = draftLabOrderReducer(initialState, previousAction);
 
-     const mockedDraft = [
-       ...selectTests(mockLabDataPanel[0].tests, 'tests'),
-       ...selectTests(mockLabDataPanel[1].tests, 'tests')
-      ];
     const newState = draftLabOrderReducer(previousState, nextAction);
     expect(newState.draftLabOrders.length).toEqual(2);
   });
@@ -62,9 +83,9 @@ describe('Draft Lab Order Reducer', () => {
   it('should delete a test panel from the draftOrder', () => {
     const previousAction = {
       type: ADD_PANEL_TO_DRAFT_LAB_ORDER,
-      orders: mockLabDataPanel[0],
+      orders: mockPanels[0],
     };
-    const nextAction = { ...previousAction, type: DELETE_PANEL_FROM_DRAFT_LAB_ORDER};
+    const nextAction = { ...previousAction, type: DELETE_PANEL_FROM_DRAFT_LAB_ORDER };
     const previousState = draftLabOrderReducer(initialState, previousAction);
 
     const newState = draftLabOrderReducer(previousState, nextAction);
@@ -74,33 +95,33 @@ describe('Draft Lab Order Reducer', () => {
   it('should delete a test panel from the draftOrder if there are already panels present', () => {
     const firstAction = {
       type: ADD_PANEL_TO_DRAFT_LAB_ORDER,
-      orders: mockLabDataPanel[0],
+      orders: mockPanels[0],
     };
 
     const secondAction = {
       type: ADD_PANEL_TO_DRAFT_LAB_ORDER,
-      orders: mockLabDataPanel[1],
+      orders: mockPanels[1],
     };
 
-    const lastAction = { ...firstAction, type: DELETE_PANEL_FROM_DRAFT_LAB_ORDER};
+    const lastAction = { ...firstAction, type: DELETE_PANEL_FROM_DRAFT_LAB_ORDER };
 
     const firstState = draftLabOrderReducer(initialState, firstAction);
     const secondState = draftLabOrderReducer(firstState, secondAction);
     const newState = draftLabOrderReducer(secondState, lastAction);
 
-    const mockedDraft = [...selectTests(mockLabDataPanel[1].tests, 'tests')];
+    const mockedDraft = mockPanels[1].setMembers;
     expect(newState.draftLabOrders.length).toEqual(1);
   });
 
   it('should delete all tests from the draftOrder at once', () => {
     const firstAction = {
       type: ADD_PANEL_TO_DRAFT_LAB_ORDER,
-      orders: mockLabDataPanel[0],
+      orders: mockPanels[0],
     };
 
     const secondAction = {
       type: ADD_PANEL_TO_DRAFT_LAB_ORDER,
-      orders: mockLabDataPanel[1],
+      orders: mockPanels[1],
     };
 
     const lastAction = { type: DELETE_ALL_ITEMS_IN_DRAFT_LAB_ORDER };
@@ -137,7 +158,7 @@ describe('Draft Lab Order Reducer', () => {
       type: ADD_TEST_TO_DRAFT_LAB_ORDER,
       order: mockTests[0],
     };
-    const nextAction = { ...lastAction, type: DELETE_TEST_FROM_DRAFT_LAB_ORDER};
+    const nextAction = { ...lastAction, type: DELETE_TEST_FROM_DRAFT_LAB_ORDER };
     const previousState = draftLabOrderReducer(initialState, nextAction);
 
     const newState = draftLabOrderReducer(previousState, nextAction);
@@ -149,20 +170,20 @@ describe('Draft Lab Order Reducer', () => {
       type: ADD_TEST_TO_DRAFT_LAB_ORDER,
       order: mockTests[0],
     };
-    
+
     const nextAction = {
       type: ADD_PANEL_TO_DRAFT_LAB_ORDER,
-      orders: mockLabDataPanel[0],
+      orders: mockPanels[0],
     };
     const previousState = draftLabOrderReducer(initialState, previousAction);
     const newState = draftLabOrderReducer(previousState, nextAction);
-    expect(newState.draftLabOrders.length).toEqual(1);
+    expect(newState.draftLabOrders.length).toEqual(2);
   });
 
-  it('should not delete a single test from the draftorder when a new panel is added', () => {    
+  it('should not delete a single test from the draftorder when a new panel is added', () => {
     const previousAction = {
       type: ADD_PANEL_TO_DRAFT_LAB_ORDER,
-      orders: mockLabDataPanel[0],
+      orders: mockPanels[0],
     };
 
     const nextAction = {
@@ -179,7 +200,7 @@ describe('Draft Lab Order Reducer', () => {
       type: ADD_TEST_TO_DRAFT_LAB_ORDER,
       order: mockTests[0],
     };
-    
+
     const nextAction = {
       ...previousAction,
       type: DELETE_TEST_FROM_DRAFT_LAB_ORDER
@@ -217,7 +238,7 @@ describe('Draft Lab Order Reducer', () => {
     };
 
     const order = { orderId: 2, orderUrgency: 'STAT' };
-    
+
 
     const action = {
       type: TOGGLE_DRAFT_LAB_ORDER_URGENCY,
@@ -238,28 +259,28 @@ describe('Draft Lab Order Reducer', () => {
           urgency: "routine",
           tests: [
             { id: 1, test: 'Hemoglobin', urgency: 'routine'},
-          { id: 2, test: 'Hematocrit', urgency: 'routine'},
-          { id: 3, test: 'blood', urgency: 'routine' },
-        ]
-      }
-    ]
-  };
-  const expectedState = {
-    id: 1,
-    name: "Hemogram",
-    labCategory: 1,
-    urgency: "STAT",
-    tests: [
-      { id: 1, test: 'Hemoglobin', urgency: 'STAT'},
-      { id: 2, test: 'Hematocrit', urgency: 'STAT'},
-      { id: 3, test: 'blood', urgency: 'STAT' },
-    ]
-  };
-  const order = { orderId: 1, orderUrgency: 'STAT' };
-  const action = {
-    type: TOGGLE_DRAFT_LAB_ORDER_URGENCY,
-    order
-  }
+            { id: 2, test: 'Hematocrit', urgency: 'routine'},
+            { id: 3, test: 'blood', urgency: 'routine' },
+          ]
+        }
+      ]
+    };
+    const expectedState = {
+      id: 1,
+      name: "Hemogram",
+      labCategory: 1,
+      urgency: "STAT",
+      tests: [
+        { id: 1, test: 'Hemoglobin', urgency: 'STAT'},
+        { id: 2, test: 'Hematocrit', urgency: 'STAT'},
+        { id: 3, test: 'blood', urgency: 'STAT' },
+      ]
+    };
+    const order = { orderId: 1, orderUrgency: 'STAT' };
+    const action = {
+      type: TOGGLE_DRAFT_LAB_ORDER_URGENCY,
+      order
+    }
 
     const newState = draftLabOrderReducer(initialState, action);
     expect(newState.draftLabOrders[0]).toEqual(expectedState)
@@ -275,26 +296,26 @@ describe('Draft Lab Order Reducer', () => {
           urgency: "STAT",
           tests: [
             { id: 1, test: 'Hemoglobin', urgency: 'STAT'},
-          { id: 2, test: 'Hematocrit', urgency: 'STAT'},
-          { id: 3, test: 'blood', urgency: 'STAT' },
-        ]
-      }
-    ]
-  };
-  const expectedState = {
-    id: 2,
-    name: "Hemogram",
-    labCategory: 1,
-    urgency: "routine",
-    tests: [
-      { id: 1, test: 'Hemoglobin', urgency: 'routine'},
-      { id: 2, test: 'Hematocrit', urgency: 'routine'},
-      { id: 3, test: 'blood', urgency: 'routine' },
-    ]
-  };
+            { id: 2, test: 'Hematocrit', urgency: 'STAT'},
+            { id: 3, test: 'blood', urgency: 'STAT' },
+          ]
+        }
+      ]
+    };
+    const expectedState = {
+      id: 2,
+      name: "Hemogram",
+      labCategory: 1,
+      urgency: "routine",
+      tests: [
+        { id: 1, test: 'Hemoglobin', urgency: 'routine'},
+        { id: 2, test: 'Hematocrit', urgency: 'routine'},
+        { id: 3, test: 'blood', urgency: 'routine' },
+      ]
+    };
 
     const order = { orderId: 2, orderUrgency: 'routine' };
-    
+
 
     const action = {
       type: TOGGLE_DRAFT_LAB_ORDER_URGENCY,


### PR DESCRIPTION
### JIRA TICKET NAME
[OEUI-212: Update the add-to-draft logic for test and panels](https://issues.openmrs.org/browse/OEUI-212)

### SUMMARY
Due to the change in data model when we switched from dummy-data to real data for test and panels, the add-to/remove-from daft functionality was breaking, this Pull Request ensures that both functionalities are working fine.