### PR TITLE
OEUI-219: Make Only Top level Lab-Tests Orderable

### DIFF
--- a/app/js/components/labOrderEntry/LabEntryForm.jsx
+++ b/app/js/components/labOrderEntry/LabEntryForm.jsx
@@ -52,8 +52,8 @@ export class LabEntryForm extends PureComponent {
     inpatientCareSetting: PropTypes.shape({
       uuid: PropTypes.string,
     }),
-    conceptsAsTests: PropTypes.array,
     conceptsAsPanels: PropTypes.array,
+    standAloneTests: PropTypes.array,
     session: PropTypes.shape({
       currentProvider: PropTypes.shape({
         person: PropTypes.shape({
@@ -81,8 +81,8 @@ export class LabEntryForm extends PureComponent {
     inpatientCareSetting: {
       uuid: '',
     },
-    conceptsAsTests: [],
     conceptsAsPanels: [],
+    standAloneTests: [],
     session: {
       currentProvider: {
         person: {
@@ -97,6 +97,7 @@ export class LabEntryForm extends PureComponent {
 
   state = {
     categoryUUID: this.props.orderables[0].uuid || 0,
+    categoryName: this.props.orderables[0].display,
     selectedPanelIds: [],
     selectedPanelTestIds: [],
   };
@@ -179,22 +180,24 @@ export class LabEntryForm extends PureComponent {
   showFieldSet = () => (
     <div>
       <LabPanelFieldSet
+        labCategoryName={this.state.categoryName}
         handleTestSelection={this.handleTestSelection}
         panels={this.props.conceptsAsPanels}
         selectedPanelIds={this.state.selectedPanelIds}
       />
       <LabTestFieldSet
+        labCategoryName={this.state.categoryName}
         handleTestSelection={this.handleTestSelection}
-        draftLabOrders={this.props.draftLabOrders}
         selectedTests={this.props.selectedTests}
-        tests={this.props.conceptsAsTests}
+        tests={this.props.standAloneTests}
       />
     </div>
   );
 
-  changeLabForm = (id) => {
+  changeLabForm = (id, name) => {
     this.setState({
       categoryUUID: id,
+      categoryName: name,
     });
   };
 
@@ -295,7 +298,7 @@ export class LabEntryForm extends PureComponent {
                           className={this.state.categoryUUID === orderable.uuid ? 'active-category' : ''}
                           href="#"
                           id="category-button"
-                          onClick={() => this.changeLabForm(orderable.uuid)}>
+                          onClick={() => this.changeLabForm(orderable.uuid, orderable.display)}>
                           {orderable.display}
                         </a>
                       </li>
@@ -330,8 +333,8 @@ export const mapStateToProps = ({
   },
   dateFormatReducer: { dateFormat },
   labConceptsReducer: {
-    conceptsAsTests,
     conceptsAsPanels,
+    standAloneTests,
   },
   openmrs: { session },
   fetchLabOrderReducer: { labOrders },
@@ -345,8 +348,8 @@ export const mapStateToProps = ({
 }) => ({
   draftLabOrders,
   dateFormat,
-  conceptsAsTests,
   conceptsAsPanels,
+  standAloneTests,
   selectedLabPanels,
   defaultTests,
   selectedTests,

--- a/app/js/components/labOrderEntry/LabPanelFieldSet.jsx
+++ b/app/js/components/labOrderEntry/LabPanelFieldSet.jsx
@@ -8,26 +8,32 @@ const formatPanelName = (panelName) => {
   return name.replace(/panel/i, '').trim();
 };
 
-const LabPanelFieldSet = ({ selectedPanelIds, handleTestSelection, panels }) => (
-  <fieldset className="fieldset">
-    <legend>Panels</legend>
-    <div className="panel-box">
-      {
-        panels.map(panel => (
-          <button
-            id="panel-button"
-            className={(selectedPanelIds.includes(panel.uuid)) ? 'active lab-tests-btn' : 'lab-tests-btn'}
-            type="button"
-            key={`${panel.uuid}`}
-            onClick={() => handleTestSelection(panel, 'panel')}
-          >
-            {formatPanelName(panel.display.toLowerCase())}
-          </button>
-        ))
-      }
-    </div>
-  </fieldset>
-);
+const LabPanelFieldSet = (props) => {
+  const {
+    selectedPanelIds, handleTestSelection, panels, labCategoryName,
+  } = props;
+  return (
+    <fieldset className="fieldset">
+      <legend>Panels</legend>
+      <div className="panel-box">
+        {
+          panels.length ?
+            panels.map(panel => (
+              <button
+                id="panel-button"
+                className={(selectedPanelIds.includes(panel.uuid)) ? 'active lab-tests-btn' : 'lab-tests-btn'}
+                type="button"
+                key={`${panel.uuid}`}
+                onClick={() => handleTestSelection(panel, 'panel')}
+              >
+                {formatPanelName(panel.display.toLowerCase())}
+              </button>
+            )) : <p>{labCategoryName} has no panels</p>
+        }
+      </div>
+    </fieldset>
+  );
+};
 
 LabPanelFieldSet.defaultProps = {
   selectedPanelIds: [],
@@ -35,6 +41,7 @@ LabPanelFieldSet.defaultProps = {
 
 LabPanelFieldSet.propTypes = {
   handleTestSelection: PropTypes.func.isRequired,
+  labCategoryName: PropTypes.string.isRequired,
   panels: PropTypes.array.isRequired,
   selectedPanelIds: PropTypes.array,
 };

--- a/app/js/components/labOrderEntry/LabTestFieldSet.jsx
+++ b/app/js/components/labOrderEntry/LabTestFieldSet.jsx
@@ -2,24 +2,28 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import '../../../css/grid.scss';
 
-const LabTestFieldSet = ({ selectedTests, handleTestSelection, tests }) => {
+const LabTestFieldSet = (props) => {
+  const {
+    selectedTests, handleTestSelection, tests, labCategoryName,
+  } = props;
   const selectedTestIds = selectedTests.map(test => test.uuid);
   return (
     <fieldset className="fieldset">
       <legend>Tests</legend>
       <div className="tests-box">
         {
-          tests.map(test => (
-            <button
-              type="button"
-              id="category-test-button"
-              key={`${test.uuid}`}
-              className={`lab-tests-btn ${(selectedTestIds.includes(test.uuid)) ? 'active' : ''}`}
-              onClick={() => handleTestSelection(test, 'single')}
-            >
-              {test.display.toLowerCase()}
-            </button>
-          ))
+          tests.length ?
+            tests.map(test => (
+              <button
+                type="button"
+                id="category-test-button"
+                key={`${test.uuid}`}
+                className={`lab-tests-btn ${(selectedTestIds.includes(test.uuid)) ? 'active' : ''}`}
+                onClick={() => handleTestSelection(test, 'single')}
+              >
+                {test.display.toLowerCase()}
+              </button>
+            )) : <p>{labCategoryName} has no Standalone Tests</p>
         }
       </div>
     </fieldset>
@@ -27,6 +31,7 @@ const LabTestFieldSet = ({ selectedTests, handleTestSelection, tests }) => {
 };
 
 LabTestFieldSet.propTypes = {
+  labCategoryName: PropTypes.string.isRequired,
   selectedTests: PropTypes.array.isRequired,
   handleTestSelection: PropTypes.func.isRequired,
   tests: PropTypes.array.isRequired,

--- a/app/js/components/labOrderEntry/styles.scss
+++ b/app/js/components/labOrderEntry/styles.scss
@@ -89,6 +89,9 @@
   .panel-box, .tests-box{
     display: flex;
     flex-wrap: wrap;
+    &>p{
+      text-transform: capitalize;
+    }
   }
 
   .lab-tests-btn{

--- a/app/js/reducers/labOrders/labConceptsReducer.js
+++ b/app/js/reducers/labOrders/labConceptsReducer.js
@@ -32,6 +32,7 @@ export default (state = initialState.labConcepts, action) => {
         concepts,
         conceptsAsTests: removeDuplicateTests(allTests),
         conceptsAsPanels: panels,
+        standAloneTests,
         loading: false,
         error: null,
       };

--- a/tests/reducers/labOrderReducers/labConceptsReducer.test.js
+++ b/tests/reducers/labOrderReducers/labConceptsReducer.test.js
@@ -56,6 +56,11 @@ describe('Lab Concepts reducer', () => {
             { uuid: '123Def-456', name: 'Concept F', set: false  },
           ]
         }
+      ],
+      standAloneTests: [
+        { uuid: '123Abc-456', name: 'Concept A', set: false },
+        { uuid: '321Abc-146', name: 'Concept C', set: false },
+        { uuid: '456Abc-123', name: 'Concept D', set: false },
       ]
     };
     const actualState = labConceptsReducer(initialState.labConcepts, mockAction);


### PR DESCRIPTION
### JIRA TICKET NAME
[OEUI-219: Only tests that are top-level should be orderable.](https://issues.openmrs.org/browse/OEUI-219)

### SUMMARY
In the previous implementation of panel/test selection when making Lab Order, any test in the tests-box can be selected regardless of if it is a standalone test or not. This pull request removes all the test that are not standalone from the tests-box consequently making only standalone tests orderable.