### PR TITLE
OEUI-223: Display lab panel-tests in a tool-tip

### DIFF
--- a/app/js/components/drugOrderEntry/styles.scss
+++ b/app/js/components/drugOrderEntry/styles.scss
@@ -44,7 +44,7 @@
   }
   
   a {
-    &.disabled {
+    &.disabled{
       pointer-events: none;
       cursor: default;
       color: gray;

--- a/app/js/components/labOrderEntry/LabPanelFieldSet.jsx
+++ b/app/js/components/labOrderEntry/LabPanelFieldSet.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 import '../../../css/grid.scss';
+import TestsToolTip from './TestsToolTip';
 
 
 const formatPanelName = (panelName) => {
@@ -21,12 +23,15 @@ const LabPanelFieldSet = (props) => {
             panels.map(panel => (
               <button
                 id="panel-button"
-                className={(selectedPanelIds.includes(panel.uuid)) ? 'active lab-tests-btn' : 'lab-tests-btn'}
+                className={classNames('lab-tests-btn tooltip', {
+                  active: selectedPanelIds.includes(panel.uuid),
+                })}
                 type="button"
                 key={`${panel.uuid}`}
                 onClick={() => handleTestSelection(panel, 'panel')}
               >
                 {formatPanelName(panel.display.toLowerCase())}
+                <TestsToolTip tests={panel.setMembers} />
               </button>
             )) : <p>{labCategoryName} has no panels</p>
         }

--- a/app/js/components/labOrderEntry/TestsToolTip.jsx
+++ b/app/js/components/labOrderEntry/TestsToolTip.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const TestsInAToolTip = ({ tests }) => (
+  <span className="tooltip-text">
+    <p>Tests included in this panel:</p>
+    <div>
+      {tests.map(test => (
+        <span key={test.uuid}>{test.display.toLowerCase()}</span>
+      ))}
+    </div>
+  </span>
+);
+
+TestsInAToolTip.propTypes = {
+  tests: PropTypes.arrayOf(PropTypes.object).isRequired,
+};
+
+export default TestsInAToolTip;

--- a/app/js/components/labOrderEntry/styles.scss
+++ b/app/js/components/labOrderEntry/styles.scss
@@ -62,7 +62,8 @@
   }
 
   .lab-form{
-    padding: 0rem 2rem;
+      padding: 0rem 2rem;
+      overflow: visible;
   }
 
   .active-category{
@@ -122,11 +123,6 @@
 
   .small-font-l{
     font-size: .9rem;
-  }
-
-  .order-form-wrapper{
-    max-height: 500px;
-    overflow-y: scroll;
   }
 
   .modified-btn{
@@ -205,5 +201,60 @@
 
   .i-black {
     color: #333;
+  }
+
+  .tooltip {
+    position: relative;
+
+    .tooltip-text {
+      visibility: hidden;
+      width: 300px;
+      background-color: white;
+      border: 1px solid grey;
+      border-radius: 6px;
+      text-align: left;
+      position: absolute;
+      bottom: 130%;
+      left: 30%;
+      z-index: 1;
+      margin-left: -60px;
+      opacity: 0;
+      transition: opacity 0.3s;
+
+      p {
+        padding: 5px 0 0 8px;
+        font-size: 13px;
+        font-weight: bold;
+      }
+
+      div {
+        display: flex;
+        flex-flow: row wrap;
+        padding: 0px 10px 5px 10px;
+
+        span {
+          margin: 0 5px 7px 0;
+          text-align: left;
+          width: 31.5%;
+          text-transform: capitalize;
+        }
+      }
+
+      &::after {
+        content: "";
+        position: absolute;
+        top: 100%;
+        left: 10%;
+        margin-left: -5px;
+        border-width: 10px;
+        border-style: solid;
+        border-color: #555 transparent transparent transparent;
+      }
+    }
+
+    &:hover .tooltip-text {
+      visibility: visible;
+      opacity: 1;
+    }
   }
 }

--- a/tests/components/labOrderEntry/TestsToolTip.test.jsx
+++ b/tests/components/labOrderEntry/TestsToolTip.test.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import TestsToolTip from '../../../app/js/components/labOrderEntry/TestsToolTip';
+
+const props = {
+  tests: [
+    { uuid: 'asampleduuid1-234', display: 'sampleA' },
+    { uuid: 'defmpleduuid1-566', display: 'sampleB' },
+    { uuid: '5sampleduuid2-788', display: 'sampleC' }
+  ]
+};
+
+describe('Component: TestsToolTip', () => {
+  it('should render correctly', () => {
+    const wrapper = shallow(<TestsToolTip tests={props.tests} />);
+    expect(wrapper).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
### JIRA TICKET NAME
[OEUI-223: Display all the lab-tests associated to a lab-panel in a tool-tip.](https://issues.openmrs.org/browse/OEUI-223)

### SUMMARY
A Lab-panel has a lot of Lab-tests associated with it, however, this is not evident/obvious from the current user interface of the application. This pull request displays all the Lab-tests associated with a Lab-panel in a ToolTip just above the Panel button when it is hovered.