### PR TITLE
OEUI-232: Make draft order list reuseable on all pages

### DIFF
--- a/app/css/openmrs-owa-orderentry.scss
+++ b/app/css/openmrs-owa-orderentry.scss
@@ -8,13 +8,17 @@
  */
 
 body {
-  font-family: 'OpenSans', Arial, sans-serif;
+  font-family: "OpenSans", Arial, sans-serif;
   -webkit-font-smoothing: subpixel-antialiased;
   max-width: 1000px;
   margin: 10px auto;
   background: #eeeeee;
   color: #363463;
   font-size: 16px;
+}
+
+*:focus {
+  outline: none;
 }
 
 .body-wrapper {
@@ -29,7 +33,29 @@ body {
   -khtml-border-radius: 5px;
   border-radius: 0px 0px 5px 5px;
   min-height: 500px;
-  justify-content: center;
+  display: flex;
+
+  .ui-tabs {
+    flex-direction: row;
+  }
+
+  .all-orders {
+    width: 100%;
+  }
+
+  .lab-order-entry {
+    flex-direction: row;
+    width: 65%;
+  }
+
+  .drug-order-entry {
+    flex-direction: row;
+    width: 65%;
+  }
+
+  .draft-wrapper {
+    margin-left: 2rem;
+  }
 }
 
 .app-title {

--- a/app/js/components/Draft.jsx
+++ b/app/js/components/Draft.jsx
@@ -1,0 +1,63 @@
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import shortid from 'shortid';
+
+export class Draft extends PureComponent {
+  renderDraftList = () => {
+    const { draftOrders } = this.props;
+    return draftOrders.map((order) => {
+      const orderName = order.display || order.drugName;
+      return (
+        <li className="draft-list small-font" key={shortid.generate()}>
+          <span className="draft-name">{orderName.toLowerCase()}</span>
+          <div className="action-btn-wrapper">
+            {/* The action are to be dynamically set */}
+          </div>
+        </li>);
+    });
+  }
+
+  render() {
+    const { draftOrders, handleDraftDiscard, handleSubmit } = this.props;
+    const numberOfDraftOrders = draftOrders.length;
+    const isDisabled = !numberOfDraftOrders;
+    return (
+      <div className="draft-spacing draft-lab-layout">
+        <h5 className="h5-draft-header">
+          Unsaved Draft Orders ({numberOfDraftOrders})
+        </h5>
+        <div className="table-container">
+          <ul className="draft-list-container">
+            {this.renderDraftList()}
+          </ul>
+        </div>
+        <br />
+        <input
+          type="button"
+          id="draft-discard-all"
+          onClick={() => handleDraftDiscard()}
+          className="button cancel modified-btn"
+          value={numberOfDraftOrders > 1 ? "Discard All" : "Discard"}
+          disabled={isDisabled}
+        />
+        <input
+          type="submit"
+          onClick={handleSubmit}
+          className="button confirm right modified-btn"
+          value="Sign and Save"
+          disabled={isDisabled}
+        />
+      </div>
+    );
+  }
+}
+
+Draft.propTypes = {
+  draftOrders: PropTypes.arrayOf(PropTypes.any).isRequired,
+  handleSubmit: PropTypes.func.isRequired,
+  handleDraftDiscard: PropTypes.func.isRequired,
+};
+
+export default Draft;
+

--- a/app/js/components/drugOrderEntry/addForm/FreeText.jsx
+++ b/app/js/components/drugOrderEntry/addForm/FreeText.jsx
@@ -87,7 +87,7 @@ const FreeText = ({
             Cancel
             </button>
           </div>
-          <div className="column-1 pull-right-8">
+          <div className="column-1">
             <button
               type="button"
               className="confirm"

--- a/app/js/components/drugOrderEntry/addForm/StandardDose.jsx
+++ b/app/js/components/drugOrderEntry/addForm/StandardDose.jsx
@@ -258,7 +258,7 @@ const StandardDose = ({
               Cancel
             </button>
           </div>
-          <div className="-1 pull-right-8">
+          <div className="-1">
             <button
               type="button"
               className="confirm"

--- a/app/js/components/drugOrderEntry/index.jsx
+++ b/app/js/components/drugOrderEntry/index.jsx
@@ -165,7 +165,7 @@ export class SearchAndAddOrder extends React.PureComponent {
       outpatientCareSetting, location, dateFormat,
     } = this.props;
     return (
-      <div className="body-wrapper drug-order-entry">
+      <div className="drug-order-entry">
         <h5 className="drug-form-header">New Drug Order</h5>
         {this.renderSearchDrug()}
         {this.renderAddForm(outpatientCareSetting)}

--- a/app/js/components/drugOrderEntry/styles.scss
+++ b/app/js/components/drugOrderEntry/styles.scss
@@ -7,7 +7,9 @@
  * graphic logo is a trademark of OpenMRS Inc.
  */
  
-.drug-order-entry {  
+.drug-order-entry {
+  margin-bottom: 10px;
+  
   .page-link {
     color: #007fff !important;
     cursor: pointer;
@@ -80,5 +82,9 @@
         text-decoration: none;
       }
     }
+  }
+
+  #notes {
+    width: 590px;
   }
 }

--- a/app/js/components/labOrderEntry/LabEntryForm.jsx
+++ b/app/js/components/labOrderEntry/LabEntryForm.jsx
@@ -266,18 +266,6 @@ export class LabEntryForm extends PureComponent {
     );
   };
 
-  renderLabDraftOrder = () => (
-    <div className="draft-lab-wrapper">
-      <LabDraftOrder
-        toggleDraftLabOrdersUgency={this.handleUrgencyChange}
-        handleDraftDiscard={this.discardTestsInDraft}
-        draftLabOrders={this.props.draftLabOrders}
-        panelTests={this.state.selectedPanelTestIds}
-        handleSubmit={() => this.handleSubmit()}
-      />
-    </div>
-  );
-
   render() {
     const {
       handleCancel, handleSubmit, renderPendingOrders, renderPastOrders,
@@ -305,7 +293,6 @@ export class LabEntryForm extends PureComponent {
                       </li>
                     ))}
                   </ul>
-                  {this.renderLabDraftOrder()}
                 </div>
                 <div className="order-form-wrapper">
                   <form className="lab-form simple-form-ui">{this.showFieldSet()}</form>

--- a/app/js/components/labOrderEntry/styles.scss
+++ b/app/js/components/labOrderEntry/styles.scss
@@ -101,12 +101,7 @@
     font-weight: bold;
     margin-right: 10px;	    
     margin-bottom: 10px;
-    flex-basis: 31.7%;
     text-transform: capitalize;
-  }
-
-  .draft-lab-wrapper{
-    width: 250px;
   }
 
   .draft-lab-layout{

--- a/app/js/components/orderEntry/OrderEntryPage.jsx
+++ b/app/js/components/orderEntry/OrderEntryPage.jsx
@@ -5,6 +5,7 @@ import { bindActionCreators } from 'redux';
 import { PatientHeader } from '@openmrs/react-components';
 import RenderOrderType from './RenderOrderType';
 import SelectOrderType from './SelectOrderType';
+import Draft from '../Draft';
 import fetchPatientCareSetting from '../../actions/careSetting';
 import { getSettingEncounterType } from '../../actions/settingEncounterType';
 import { getSettingEncounterRole } from '../../actions/settingEncounterRole';
@@ -48,6 +49,19 @@ export class OrderEntryPage extends PureComponent {
     }
     return this.props.setSelectedOrder({ currentOrderType: newOrderType });
   };
+
+  renderDraftOrder = () => {
+    const { draftDrugOrders, draftLabOrders } = this.props;
+    const allDraftOrders = [...draftDrugOrders, ...draftLabOrders.orders];
+    return (
+      <div className="draft-wrapper">
+        <Draft
+          handleDraftDiscard={() => {}}
+          draftOrders={allDraftOrders}
+          handleSubmit={() => {}}
+        />
+      </div>);
+  }
 
   render() {
     const query = new URLSearchParams(this.props.location.search);
@@ -159,7 +173,13 @@ export class OrderEntryPage extends PureComponent {
                 currentOrderType={this.props.currentOrderType}
               />
             </div>
-            <RenderOrderType currentOrderTypeID={this.props.currentOrderType.id} {...this.props} />
+            <div className="body-wrapper drug-order-entry">
+              <RenderOrderType
+                currentOrderTypeID={this.props.currentOrderType.id}
+                {...this.props}
+              />
+              {this.props.currentOrderType.id && this.renderDraftOrder()}
+            </div>
           </div>
         ) : (
           <div className="error-notice">
@@ -220,6 +240,8 @@ OrderEntryPage.propTypes = {
   fetchPatientNote: PropTypes.func.isRequired,
   setSelectedOrder: PropTypes.func.isRequired,
   currentOrderType: PropTypes.object,
+  draftLabOrders: PropTypes.array.isRequired,
+  draftDrugOrders: PropTypes.arrayOf(PropTypes.any).isRequired,
 };
 
 OrderEntryPage.defaultProps = {
@@ -239,6 +261,10 @@ const mapStateToProps = ({
   patientReducer: { patient },
   noteReducer: { note },
   orderSelectionReducer: { currentOrderType },
+  draftReducer: {
+    draftDrugOrders,
+    draftLabOrders,
+  },
 }) => ({
   outpatientCareSetting,
   dateFormatReducer,
@@ -248,6 +274,8 @@ const mapStateToProps = ({
   patient,
   note,
   currentOrderType,
+  draftDrugOrders,
+  draftLabOrders,
 });
 
 const actionCreators = {

--- a/app/js/components/orderEntry/RenderOrderType.jsx
+++ b/app/js/components/orderEntry/RenderOrderType.jsx
@@ -8,11 +8,7 @@ import AllOrders from './AllOrders';
 const RenderOrderType = (props) => {
   switch (props.currentOrderTypeID) {
     case orderTypes.LAB_ORDER.id: {
-      return (
-        <div className="body-wrapper">
-          <LabEntryForm />
-        </div>
-      );
+      return (<LabEntryForm />);
     }
     case orderTypes.DRUG_ORDER.id: {
       return (
@@ -24,11 +20,7 @@ const RenderOrderType = (props) => {
       );
     }
     default: {
-      return (
-        <div className="body-wrapper">
-          <AllOrders />
-        </div>
-      );
+      return (<AllOrders />);
     }
   }
 };

--- a/app/js/components/orderEntry/styles.scss
+++ b/app/js/components/orderEntry/styles.scss
@@ -213,3 +213,71 @@
     }
   }
 }
+
+.draft-list-container{
+  .draft-list {
+    display: block;
+    background: #EBEBEB;
+    padding: 0 0 0 10px;
+    margin: 5px 0px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    position: relative;
+    border-radius: 5px;
+    &:hover{
+      background: #D3D3D3;
+      transition: all 200ms ease-in-out;
+      -webkit-transition: all 200ms ease-in-out;
+      -moz-transition: all 200ms ease-in-out;
+    }
+  }
+  .draft-name {
+    text-transform: capitalize;
+  }
+
+  /* Icon styles */
+  .i-gray {
+    color: gray
+  }
+  
+  .i-red {
+    color: red;
+  }
+}
+
+.draft-wrapper{
+  .action-btn-wrapper{
+    display: flex;
+  }
+
+  .action-btn {
+    cursor: pointer;
+    width: 50%;
+    height: 100% !important;
+    border-left: 1px #d0d0d0 solid;
+    display: inline-flex;
+    justify-content: center;
+    padding: .7em;
+    transition: all ease-in-out 200ms;
+    -moz-transition: all ease-in-out 200ms;
+    -webkit-transition: all ease-in-out 200ms;
+
+    #draft-discard-btn {
+      color: #ff3d3d;
+    }
+
+    &:hover {
+      background-color: rgba(0, 0, 0, .2);
+
+      a {
+        i.scale {
+          text-decoration: none;
+          transform: scale(1.7);
+          -webkit-transform: scale(1.7);
+          -moz-transform: scale(1.7);
+        }
+      }
+    }
+  }  
+}

--- a/tests/components/Draft.test.jsx
+++ b/tests/components/Draft.test.jsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { Draft } from '../../app/js/components/Draft';
+
+let props;
+let mountedComponent;
+
+props = {
+  draftOrders: [
+    { uuid: 6, display: 'hermatocrite' }
+  ],
+  handleSubmit: jest.fn(),
+  handleDraftDiscard: jest.fn(),
+};
+
+const getComponent = () => {
+  if (!mountedComponent) {
+    mountedComponent = shallow(<Draft {...props} />);
+  }
+  return mountedComponent;
+};
+
+describe('Component: Draft', () => {
+  beforeEach(() => {
+    mountedComponent = undefined;
+  });
+
+  it('should render on initial setup', () => {
+    const component = getComponent();
+    expect(component).toMatchSnapshot();
+  });
+
+  it('Should be able to display drug data to the list', () => {
+    const component = getComponent();
+    component.setProps({ draftOrders: [
+      { uuid: 6, drugName: 'paracetamol' }
+    ]});
+    const draftName = component.find('.draft-name');
+    expect(draftName.exists()).toBeTruthy();
+    expect(draftName.props().children).toEqual('paracetamol');
+  });
+
+  it('Should simulate the discard event', () => {
+    const component = getComponent();
+    component.setProps({ draftOrders: [
+      { uuid: 6, drugName: 'paracetamol' },
+      { uuid: 7, display: 'hermatology' }
+    ]});
+    const discardButton = component.find('#draft-discard-all');
+    discardButton.simulate('click', {});
+    expect(props.handleDraftDiscard).toBeCalled();
+  });
+});
+

--- a/tests/components/labOrderEntry/LabEntryForm.test.jsx
+++ b/tests/components/labOrderEntry/LabEntryForm.test.jsx
@@ -158,39 +158,36 @@ describe('Component: LabEntryForm', () => {
     expect(dispatch).toBeCalled();
   });
 
-  it('should dispatch an action to handle single test deletion', () => {
-    const instance = getComponent().instance();
-    instance.state.selectedPanelIds = [1];
-
-    const dispatch = jest.spyOn(props, 'dispatch');
-    instance.discardTestsInDraft(mockTest, 'single');
-    expect(dispatch).toBeCalled();
+  it('should dispatch an action to handle single test deletion', () => {	
+    const instance = getComponent().instance();	
+    instance.state.selectedPanelIds = [1];	
+     const dispatch = jest.spyOn(props, 'dispatch');	
+    instance.discardTestsInDraft(mockTest, 'single');	
+    expect(dispatch).toBeCalled();	
   });
 
-  it('should dispatch an action to handle panel deletion', () => {
-    const instance = getComponent().instance();
-    instance.state.selectedPanelIds = [1];
-
-    const dispatch = jest.spyOn(props, 'dispatch');
-    instance.discardTestsInDraft(mockPanel, 'panel');
-    expect(dispatch).toBeCalled();
+  it('should dispatch an action to handle panel deletion', () => {	
+    const instance = getComponent().instance();	
+    instance.state.selectedPanelIds = [1];	
+     const dispatch = jest.spyOn(props, 'dispatch');	
+    instance.discardTestsInDraft(mockPanel, 'panel');	
+    expect(dispatch).toBeCalled();	
   });
 
-  it('should dispatch an action to handle deletion of all items from the draft', () => {
-    const instance = getComponent().instance();
-    instance.state.selectedPanelIds = [1];
-
-    const dispatch = jest.spyOn(props, 'dispatch');
-    instance.discardTestsInDraft();
-    expect(dispatch).toBeCalled();
+  it('should dispatch an action to handle deletion of all items from the draft', () => {	
+    const instance = getComponent().instance();	
+    instance.state.selectedPanelIds = [1];	
+     const dispatch = jest.spyOn(props, 'dispatch');	
+    instance.discardTestsInDraft();	
+    expect(dispatch).toBeCalled();	
   });
 
-  it('should toggle the urgency state of a test', () => {
-    const instance = getComponent().instance();
-    const dispatch = jest.spyOn(props, 'dispatch');
-    instance.handleUrgencyChange();
+  it('should toggle the urgency state of a test', () => {	
+    const instance = getComponent().instance();	
+    const dispatch = jest.spyOn(props, 'dispatch');	
+    instance.handleUrgencyChange();	
     expect(dispatch).toBeCalled();
-  }) 
+  });
 
   it(`should change the default lab form's tests category by toggling component state`, () => {
     const component = getComponent();
@@ -205,8 +202,8 @@ describe('Component: LabEntryForm', () => {
 
   it('shows a toast prompt when test is submitted successfully', () => {
     const component = getComponent();
-    const addButton = component.find('.confirm');
-    addButton.simulate('click', {});
+    const instance = component.instance();
+    instance.handleSubmit(); // This should be change on the fix ticket for submiting all draft orders
 
     component.setProps({
       ...component.props(),
@@ -223,8 +220,8 @@ describe('Component: LabEntryForm', () => {
 
   it('shows a toast prompt when there is an error in submission', () => {
     const component = getComponent();
-    const addButton = component.find('.confirm').at(0);
-    addButton.simulate('click', {});
+    const instance = component.instance();
+    instance.handleSubmit(); // This should be change on the fix ticket for submiting all draft orders
     component.setProps({
       ...component.props(),
       createLabOrderReducer: {

--- a/tests/components/orderentry/OrderEntryPage.test.jsx
+++ b/tests/components/orderentry/OrderEntryPage.test.jsx
@@ -41,7 +41,17 @@ describe('Test for Order entry page when orderentryowa.encounterType is set', ()
       outpatientCareSetting: { uuid: '5677666' },
       inpatientCareSetting: { uuid: '6766667' },
       location: {search: '?patient=esere_shbfidfb_343ffd'},
-      currentOrderType: {},
+      currentOrderType: {
+        id: '94386782390'
+      },
+      draftLabOrders: {
+        orders: [
+          { display: 'Hemoglobin', uuid: '12746hfgjff' },
+          { display: 'Hematocrit', uuid: '12746hfgjff' },
+          { display: 'blood', uuid: '12746hfgjff' },
+        ]
+      },
+      draftDrugOrders: [{ drugName: 'paracetamol' }],
     };
     mountedComponent = undefined;
   });
@@ -70,7 +80,8 @@ describe('Test for Order entry page when orderentryowa.encounterType is set', ()
     const component =  shallow(<OrderEntryPage {...props} />);
     const componentInstance = component.instance();
     const orderTypesAsArray = Object.values(orderTypes);
-    expect(props.currentOrderType).toEqual({});
+    const mockCurrentOrderType = { id: '94386782390' };
+    expect(props.currentOrderType).toEqual(mockCurrentOrderType);
     componentInstance.switchOrderType(orderTypesAsArray[1]);
     expect(props.setSelectedOrder).toBeCalled();
   });
@@ -109,7 +120,11 @@ describe('Test for Order entry page when orderentryowa.encounterType is not set'
       },
       outpatientCareSetting: { uuid: '5677666' },
       inpatientCareSetting: { uuid: '6766667' },
-      location: {search: '?patient=esere_shbfidfb_343ffd'}
+      location: {search: '?patient=esere_shbfidfb_343ffd'},
+      draftLabOrders: {
+        orders: [{ display: 'Hemoglobin', uuid: '12746hfgjff' }],
+      },
+      draftDrugOrders: [{ drugName: 'paracetamol' }],
     };
     mountedComponent = undefined;
   });
@@ -157,7 +172,11 @@ describe('Test for Order entry page when orderentryowa.encounterRole is set', ()
       },
       outpatientCareSetting: { uuid: '5677666' },
       inpatientCareSetting: { uuid: '6766667' },
-      location: {search: '?patient=esere_shbfidfb_343ffd'}
+      location: {search: '?patient=esere_shbfidfb_343ffd'},
+      draftLabOrders: {
+        orders: [{ display: 'Hemoglobin', uuid: '12746hfgjff' }],
+      },
+      draftDrugOrders: [{ drugName: 'paracetamol' }],
     };
     mountedComponent = undefined;
   });
@@ -193,7 +212,11 @@ describe('Test for Order entry page when orderentryowa.encounterRole is not set'
       },
       outpatientCareSetting: { uuid: '5677666' },
       inpatientCareSetting: { uuid: '6766667' },
-      location: {search: '?patient=esere_shbfidfb_343ffd'}
+      location: {search: '?patient=esere_shbfidfb_343ffd'},
+      draftLabOrders: {
+        orders: [{ display: 'Hemoglobin', uuid: '12746hfgjff' }],
+      },
+      draftDrugOrders: [{ drugName: 'paracetamol' }],
     };
     mountedComponent = undefined;
   });
@@ -234,7 +257,11 @@ describe('Test for Order entry page when orderentryowa.dateAndTimeFormat is set'
       },
       outpatientCareSetting: { uuid: '5677666' },
       inpatientCareSetting: { uuid: '6766667' },
-      location: {search: '?patient=esere_shbfidfb_343ffd'}
+      location: {search: '?patient=esere_shbfidfb_343ffd'},
+      draftLabOrders: {
+        orders: [{ display: 'Hemoglobin', uuid: '12746hfgjff' }],
+      },
+      draftDrugOrders: [{ drugName: 'paracetamol' }],
     };
     mountedComponent = undefined;
   });
@@ -270,7 +297,11 @@ describe('Test for Order entry page when orderentryowa.encounterRole is not set'
       orderSelectionReducer: { currentOrderType: {} },
       outpatientCareSetting: { uuid: '5677666' },
       inpatientCareSetting: { uuid: '6766667' },
-      location: {search: '?patient=esere_shbfidfb_343ffd'}
+      location: {search: '?patient=esere_shbfidfb_343ffd'},
+      draftLabOrders: {
+        orders: [{ display: 'Hemoglobin', uuid: '12746hfgjff' }],
+      },
+      draftDrugOrders: [{ drugName: 'paracetamol' }],
     };
     mountedComponent = undefined;
   });
@@ -284,7 +315,6 @@ describe('Test for Order entry page when orderentryowa.encounterRole is not set'
     expect(mountedComponent.find('div.error-notice').length).toBe(1);
   });
 });
-
 
 describe('Connected OrderEntryPage component', () => {
   it('component successfully rendered', () => {
@@ -306,7 +336,13 @@ describe('Connected OrderEntryPage component', () => {
           personName: { display: 'joey bart'}
         }
       },
-      noteReducer: { note: []}
+      noteReducer: { note: []},
+      draftReducer: {
+        draftLabOrders: {
+          orders: [],
+        },
+        draftDrugOrders: [{ drugName: 'paracetamol' }],
+      },
     });
     const props = {
       location: {search: '?patient=esere_shbfidfb_343ffd'}


### PR DESCRIPTION
### **JIRA TICKET NAME**
[OEUI-232: Make a Draft order component reusable in all order page](https://issues.openmrs.org/browse/OEUI-232)

### **Summary**
- This should make a Draft order component reusable and visible in all order page.

## I have checked that on this Pull request

- [x] I can successfully create Drug orders
- [x] I can successfully create Lab orders
- [x] I can successfully search for drug orders
