### PR TITLE
OEUI-238: Toggle lab urgency from shared draft

### DIFF
--- a/app/js/actions/draftActions.js
+++ b/app/js/actions/draftActions.js
@@ -1,0 +1,26 @@
+import { TOGGLE_DRAFT_LAB_ORDER_URGENCY } from './actionTypes';
+import constants from '../utils/constants';
+
+const toggleDraftLabOrderUrgency = (order) => {
+  const urgencyTypeToggled = {
+    ROUTINE: constants.STAT,
+    STAT: constants.ROUTINE,
+  };
+  const orderUuid = order.uuid;
+  let orderUrgency;
+  const hasUrgencyProperty = Object.prototype.hasOwnProperty.call(order, 'urgency');
+  orderUrgency = constants.STAT;
+  if (hasUrgencyProperty) {
+    orderUrgency = urgencyTypeToggled[order.urgency];
+  }
+  const draftOrder = {
+    orderUuid,
+    orderUrgency,
+  };
+  return {
+    type: TOGGLE_DRAFT_LAB_ORDER_URGENCY,
+    order: draftOrder,
+  };
+};
+
+export default toggleDraftLabOrderUrgency;

--- a/app/js/actions/draftLabOrderAction.js
+++ b/app/js/actions/draftLabOrderAction.js
@@ -27,11 +27,6 @@ export const removeTestPanelFromDraft = orders => ({
   orders,
 });
 
-export const toggleDraftLabOrdersUgency = order => ({
-  type: TOGGLE_DRAFT_LAB_ORDER_URGENCY,
-  order,
-});
-
 export const addTestPanelToDraft = orders => ({
   type: ADD_PANEL_TO_DRAFT_LAB_ORDER,
   orders,

--- a/app/js/components/Draft.jsx
+++ b/app/js/components/Draft.jsx
@@ -30,7 +30,8 @@ export class Draft extends PureComponent {
                 <IconButton
                   iconClass={iconClass}
                   iconTitle="Urgency"
-                  onClick={() => {}}
+                  dataContext={order}
+                  onClick={this.props.toggleDraftLabOrderUrgency}
                   icon="&#x25B2;"
                   id="draft-toggle-btn icon-btn-anchor"
                 /> :
@@ -94,6 +95,7 @@ Draft.propTypes = {
   draftOrders: PropTypes.arrayOf(PropTypes.any).isRequired,
   handleSubmit: PropTypes.func.isRequired,
   handleDraftDiscard: PropTypes.func.isRequired,
+  toggleDraftLabOrderUrgency: PropTypes.func.isRequired,
 };
 
 export default Draft;

--- a/app/js/components/labOrderEntry/LabEntryForm.jsx
+++ b/app/js/components/labOrderEntry/LabEntryForm.jsx
@@ -16,7 +16,6 @@ import {
   removeTestFromDraft,
   addTestToDraft,
   deleteDraftLabOrder,
-  toggleDraftLabOrdersUgency,
 } from '../../actions/draftLabOrderAction';
 import '../../../css/grid.scss';
 import './styles.scss';
@@ -164,10 +163,6 @@ export class LabEntryForm extends PureComponent {
       if (!isSelectedPanelTest && isSelected) dispatch(removeTestFromDraft(item));
       if (!isSelectedPanelTest && !isSelected)dispatch(addTestToDraft(item));
     }
-  }
-
-  handleUrgencyChange = (order) => {
-    this.props.dispatch(toggleDraftLabOrdersUgency(order));
   }
 
   discardTestsInDraft = (test, action) => {

--- a/app/js/components/orderEntry/OrderEntryPage.jsx
+++ b/app/js/components/orderEntry/OrderEntryPage.jsx
@@ -14,6 +14,7 @@ import getDateFormat from '../../actions/dateFormat';
 import activeOrderAction from '../../actions/activeOrderAction';
 import { fetchPatientRecord, fetchPatientNote } from '../../actions/patient';
 import { setSelectedOrder } from '../../actions/orderAction';
+import toggleDraftLabOrderUrgency from '../../actions/draftActions';
 import imageLoader from '../../../img/loading.gif';
 import './styles.scss';
 
@@ -59,6 +60,7 @@ export class OrderEntryPage extends PureComponent {
           handleDraftDiscard={() => {}}
           draftOrders={allDraftOrders}
           handleSubmit={() => {}}
+          toggleDraftLabOrderUrgency={this.props.toggleDraftLabOrderUrgency}
         />
       </div>);
   }
@@ -242,6 +244,7 @@ OrderEntryPage.propTypes = {
   currentOrderType: PropTypes.object,
   draftLabOrders: PropTypes.object.isRequired,
   draftDrugOrders: PropTypes.arrayOf(PropTypes.any).isRequired,
+  toggleDraftLabOrderUrgency: PropTypes.func.isRequired,
 };
 
 OrderEntryPage.defaultProps = {
@@ -288,6 +291,7 @@ const actionCreators = {
   fetchPatientNote,
   setSelectedOrder,
   activeOrderAction,
+  toggleDraftLabOrderUrgency,
 };
 
 const mapDispatchToProps = dispatch => bindActionCreators(actionCreators, dispatch);

--- a/tests/actions/draftActions.test.js
+++ b/tests/actions/draftActions.test.js
@@ -1,0 +1,54 @@
+import { TOGGLE_DRAFT_LAB_ORDER_URGENCY } from '../../app/js/actions/actionTypes';
+
+import toggleDraftLabOrderUrgency from '../../app/js/actions/draftActions';
+
+describe('Draft Actions', () => {
+  beforeEach(() => moxios.install());
+  afterEach(() => moxios.uninstall());
+
+  it(`should dispatch TOGGLE_DRAFT_LAB_ORDER_URGENCY 
+      and set order urgency to STAT if order has no urgency`, async (done) => {
+      const labOrder = { uuid: 'abxzy-123'};
+      const expectedActions = [{
+        type: TOGGLE_DRAFT_LAB_ORDER_URGENCY,
+        order: {
+          orderUuid: labOrder.uuid, 
+          orderUrgency: 'STAT',
+        },
+      }];
+      const store = mockStore({});
+      await store.dispatch(toggleDraftLabOrderUrgency(labOrder));
+      expect(store.getActions()).toEqual(expectedActions);
+      done();
+    });
+  it(`should dispatch TOGGLE_DRAFT_LAB_ORDER_URGENCY 
+      and set order urgency to ROUTINE if urgency was STAT`, async (done) => {
+      const labOrder = { uuid: 'abxzy-123', urgency: 'STAT' };
+      const expectedActions = [{
+        type: TOGGLE_DRAFT_LAB_ORDER_URGENCY,
+        order: {
+          orderUuid: labOrder.uuid, 
+          orderUrgency: 'ROUTINE',
+        },
+      }];
+      const store = mockStore({});
+      await store.dispatch(toggleDraftLabOrderUrgency(labOrder));
+      expect(store.getActions()).toEqual(expectedActions);
+      done();
+    });
+    it(`should dispatch TOGGLE_DRAFT_LAB_ORDER_URGENCY 
+      and set order urgency to STAT if urgency was ROUTINE`, async (done) => {
+      const labOrder = { uuid: 'abxzy-123', urgency: 'ROUTINE' };
+      const expectedActions = [{
+        type: TOGGLE_DRAFT_LAB_ORDER_URGENCY,
+        order: {
+          orderUuid: labOrder.uuid, 
+          orderUrgency: 'STAT',
+        },
+      }];
+      const store = mockStore({});
+      await store.dispatch(toggleDraftLabOrderUrgency(labOrder))
+      expect(store.getActions()).toEqual(expectedActions);
+      done();
+    });
+});

--- a/tests/actions/draftLabOrderAction.test.js
+++ b/tests/actions/draftLabOrderAction.test.js
@@ -12,7 +12,6 @@ import {
   removeTestPanelFromDraft,
   addTestPanelToDraft,
   deleteDraftLabOrder,
-  toggleDraftLabOrdersUgency,
 } from '../../app/js/actions/draftLabOrderAction';
 
 import { panelData, testsData } from '../../app/js/components/labOrderEntry/labData';
@@ -82,23 +81,6 @@ describe('Lab Order Actions', () => {
     }
     const store = mockStore({});
     await store.dispatch(addTestPanelToDraft(orders), () => {
-      expect(store.getActions()).toEqual(expectedActions);
-    });
-    done();
-  });
-
-
-  it('should dispatch toggling a draft lab order urgency successfuly', async (done) => {
-    const order = { orderId: 1, orderUrgency: 'SWAT' };
-
-    const expectedActions = {
-      TOGGLE_DRAFT_LAB_ORDER_URGENCY,
-      order
-    }
-
-    const store = mockStore({});
-
-    await store.dispatch(toggleDraftLabOrdersUgency(order), () => {
       expect(store.getActions()).toEqual(expectedActions);
     });
     done();

--- a/tests/components/Draft.test.jsx
+++ b/tests/components/Draft.test.jsx
@@ -10,6 +10,7 @@ props = {
   ],
   handleSubmit: jest.fn(),
   handleDraftDiscard: jest.fn(),
+  toggleDraftLabOrderUrgency: jest.fn(),
 };
 
 const getComponent = () => {

--- a/tests/components/labOrderEntry/LabEntryForm.test.jsx
+++ b/tests/components/labOrderEntry/LabEntryForm.test.jsx
@@ -182,13 +182,6 @@ describe('Component: LabEntryForm', () => {
     expect(dispatch).toBeCalled();	
   });
 
-  it('should toggle the urgency state of a test', () => {	
-    const instance = getComponent().instance();	
-    const dispatch = jest.spyOn(props, 'dispatch');	
-    instance.handleUrgencyChange();	
-    expect(dispatch).toBeCalled();
-  });
-
   it(`should change the default lab form's tests category by toggling component state`, () => {
     const component = getComponent();
     const instance = component.instance();

--- a/tests/components/orderentry/OrderEntryPage.test.jsx
+++ b/tests/components/orderentry/OrderEntryPage.test.jsx
@@ -33,6 +33,7 @@ describe('Test for Order entry page when orderentryowa.encounterType is set', ()
         settingEncounterRole: 'Admin role',
         roleError: '',
       },
+      toggleDraftLabOrderUrgency: jest.fn(),
       dateFormatReducer: {
         dateFormat: 'DD-MMM-YYYY HH:mm',
         error: '',
@@ -114,6 +115,7 @@ describe('Test for Order entry page when orderentryowa.encounterType is not set'
         settingEncounterRole: 'Admin role',
         roleError: '',
       },
+      toggleDraftLabOrderUrgency: jest.fn(),
       dateFormatReducer: {
         dateFormat: 'DD-MMM-YYYY HH:mm',
         error: '',
@@ -165,6 +167,7 @@ describe('Test for Order entry page when orderentryowa.encounterRole is set', ()
         settingEncounterRole: 'Admin role',
         roleError: '',
       },
+      toggleDraftLabOrderUrgency: jest.fn(),
       orderSelectionReducer: { currentOrderType: {} },
       dateFormatReducer: {
         dateFormat: 'DD-MMM-YYYY HH:mm',
@@ -206,6 +209,7 @@ describe('Test for Order entry page when orderentryowa.encounterRole is not set'
         settingEncounterRole: '',
         roleError: 'error error',
       },
+      toggleDraftLabOrderUrgency: jest.fn(),
       dateFormatReducer: {
         dateFormat: 'DD-MMM-YYYY HH:mm',
         error: '',
@@ -250,6 +254,7 @@ describe('Test for Order entry page when orderentryowa.dateAndTimeFormat is set'
         settingEncounterRole: 'Admin role',
         roleError: '',
       },
+      toggleDraftLabOrderUrgency: jest.fn(),
       orderSelectionReducer: { currentOrderType: {} },
       dateFormatReducer: {
         dateFormat: 'DD-MMM-YYYY HH:mm',
@@ -290,6 +295,7 @@ describe('Test for Order entry page when orderentryowa.encounterRole is not set'
         settingEncounterRole: 'Admin role',
         roleError: '',
       },
+      toggleDraftLabOrderUrgency: jest.fn(),
       dateFormatReducer: {
         dateFormat: '',
         error: 'incomplete config',
@@ -327,6 +333,7 @@ describe('Connected OrderEntryPage component', () => {
         settingEncounterType: 'order entry',
         error: ''
       },
+      toggleDraftLabOrderUrgency: jest.fn(),
       orderSelectionReducer: { currentOrderType: {} },
       patientReducer: {
         patient: {


### PR DESCRIPTION
### **JIRA TICKET NAME**
[OEUI-238: User should be able to toggle the urgency of a lab order from the draft.](https://issues.openmrs.org/browse/OEUI-238)

### **Summary**
This pull request adds the functionality that enables users to toggle the urgency of Lab Orders from the new shared draft.