### PR TITLE
OEUI-239: User should be able to discard a lab order from the draft list

### DIFF
--- a/app/js/actions/draftActions.js
+++ b/app/js/actions/draftActions.js
@@ -2,6 +2,11 @@ import { DELETE_DRAFT_DRUG_ORDER_SUCCESS, TOGGLE_DRAFT_LAB_ORDER_URGENCY } from 
 import { DRUG_ORDER } from '../components/orderEntry/orderTypes';
 import { selectDrugSuccess } from './drug';
 import { setSelectedOrder } from './orderAction';
+import {
+  removeTestFromDraft,
+  removeTestPanelFromDraft,
+  deleteDraftLabOrder,
+} from '../actions/draftLabOrderAction';
 import constants from '../utils/constants';
 
 export const toggleDraftLabOrderUrgency = (order) => {
@@ -39,4 +44,10 @@ export const editDraftDrugOrder = order => (dispatch) => {
     activity: 'DRAFT_ORDER_EDIT',
   }));
   dispatch(deleteDraftOrder(order));
+};
+
+export const discardTestsInDraft = (test = {}) => (dispatch) => {
+  if (test.draftType === 'single') return dispatch(removeTestFromDraft(test.order));
+  if (test.draftType === 'panel') return dispatch(removeTestPanelFromDraft(test.order));
+  return dispatch(deleteDraftLabOrder());
 };

--- a/app/js/components/Draft.jsx
+++ b/app/js/components/Draft.jsx
@@ -7,7 +7,7 @@ import IconButton from './button/IconButton';
 
 export class Draft extends PureComponent {
   renderDraftList = () => {
-    const { draftOrders } = this.props;
+    const { draftOrders, handleDraftDiscard } = this.props;
     return draftOrders.map((order) => {
       const isPanel = !!order.set;
       const draftType = !isPanel ? 'single' : 'panel';
@@ -49,7 +49,8 @@ export class Draft extends PureComponent {
                 iconClass="icon-remove"
                 iconTitle="Discard"
                 id="draft-discard-btn"
-                onClick={() => {}}
+                dataContext={{ order, draftType }}
+                onClick={handleDraftDiscard}
               />
             </span>
           </div>

--- a/app/js/components/button/IconButton.jsx
+++ b/app/js/components/button/IconButton.jsx
@@ -24,6 +24,7 @@ class IconButton extends PureComponent {
     event.stopPropagation();
     this.props.onClick(this.props.dataContext);
   }
+
   render() {
     const {
       id, iconClass, iconTitle, icon,

--- a/app/js/components/orderEntry/OrderEntryPage.jsx
+++ b/app/js/components/orderEntry/OrderEntryPage.jsx
@@ -14,7 +14,11 @@ import getDateFormat from '../../actions/dateFormat';
 import activeOrderAction from '../../actions/activeOrderAction';
 import { fetchPatientRecord, fetchPatientNote } from '../../actions/patient';
 import { setSelectedOrder } from '../../actions/orderAction';
-import { editDraftDrugOrder, toggleDraftLabOrderUrgency } from '../../actions/draftActions';
+import {
+  editDraftDrugOrder,
+  toggleDraftLabOrderUrgency,
+  discardTestsInDraft,
+} from '../../actions/draftActions';
 import imageLoader from '../../../img/loading.gif';
 import './styles.scss';
 
@@ -57,7 +61,7 @@ export class OrderEntryPage extends PureComponent {
     return (
       <div className="draft-wrapper">
         <Draft
-          handleDraftDiscard={() => {}}
+          handleDraftDiscard={this.props.discardTestsInDraft}
           draftOrders={allDraftOrders}
           handleSubmit={() => {}}
           toggleDraftLabOrderUrgency={this.props.toggleDraftLabOrderUrgency}
@@ -247,6 +251,7 @@ OrderEntryPage.propTypes = {
   draftLabOrders: PropTypes.object.isRequired,
   draftDrugOrders: PropTypes.arrayOf(PropTypes.any).isRequired,
   toggleDraftLabOrderUrgency: PropTypes.func.isRequired,
+  discardTestsInDraft: PropTypes.func.isRequired,
 };
 
 OrderEntryPage.defaultProps = {
@@ -295,6 +300,7 @@ const actionCreators = {
   activeOrderAction,
   toggleDraftLabOrderUrgency,
   editDraftDrugOrder,
+  discardTestsInDraft,
 };
 
 const mapDispatchToProps = dispatch => bindActionCreators(actionCreators, dispatch);

--- a/tests/actions/draftActions.test.js
+++ b/tests/actions/draftActions.test.js
@@ -2,25 +2,37 @@ import {
   TOGGLE_DRAFT_LAB_ORDER_URGENCY,
   SET_SELECTED_ORDER,
   DELETE_DRAFT_DRUG_ORDER_SUCCESS,
-  SELECT_DRUG
-} from '../../app/js/actions/actionTypes';
-import { DRUG_ORDER } from '../../app/js/components/orderEntry/orderTypes';
-import { editDraftDrugOrder, toggleDraftLabOrderUrgency } from '../../app/js/actions/draftActions';
+  SELECT_DRUG,
+  DELETE_TEST_FROM_DRAFT_LAB_ORDER,
+  DELETE_PANEL_FROM_DRAFT_LAB_ORDER,
+  DELETE_ALL_ITEMS_IN_DRAFT_LAB_ORDER
+} from "../../app/js/actions/actionTypes";
+import { DRUG_ORDER } from "../../app/js/components/orderEntry/orderTypes";
+import {
+  editDraftDrugOrder,
+  toggleDraftLabOrderUrgency,
+  discardTestsInDraft,
+} from "../../app/js/actions/draftActions";
 
-describe('Draft Actions', () => {
+describe("Draft Actions", () => {
   beforeEach(() => moxios.install());
   afterEach(() => moxios.uninstall());
 
-  describe('editDraftDrugOrder action creator', () => {
-    it(`should dispatch SELECT_DRUG, SET_SELECTED_ORDER, DELETE_DRAFT_DRUG_ORDER_SUCCESS`, async (done) => {
+  describe("editDraftDrugOrder action creator", () => {
+    it(`should dispatch SELECT_DRUG, SET_SELECTED_ORDER, DELETE_DRAFT_DRUG_ORDER_SUCCESS`, async done => {
       const drugOrder = {
-        drug: '1asbcddd-tu7',
+        drug: "1asbcddd-tu7"
         // some other drug order property
       };
       const expectedActions = [
         { type: SELECT_DRUG, drug: drugOrder.drug },
-        { type: SET_SELECTED_ORDER, currentOrderType: DRUG_ORDER, order: drugOrder, activity: 'DRAFT_ORDER_EDIT' },
-        { type: DELETE_DRAFT_DRUG_ORDER_SUCCESS, order: drugOrder },
+        {
+          type: SET_SELECTED_ORDER,
+          currentOrderType: DRUG_ORDER,
+          order: drugOrder,
+          activity: "DRAFT_ORDER_EDIT"
+        },
+        { type: DELETE_DRAFT_DRUG_ORDER_SUCCESS, order: drugOrder }
       ];
       const store = mockStore({});
       await store.dispatch(editDraftDrugOrder(drugOrder));
@@ -29,51 +41,104 @@ describe('Draft Actions', () => {
     });
   });
 
-  describe('toggleDraftLabOrderUrgency action creator', () => {
+  describe("toggleDraftLabOrderUrgency action creator", () => {
     it(`should dispatch TOGGLE_DRAFT_LAB_ORDER_URGENCY 
-    and set order urgency to STAT if order has no urgency`, async (done) => {
-        const labOrder = { uuid: 'abxzy-123' };
-        const expectedActions = [{
+    and set order urgency to STAT if order has no urgency`, async done => {
+      const labOrder = { uuid: "abxzy-123" };
+      const expectedActions = [
+        {
           type: TOGGLE_DRAFT_LAB_ORDER_URGENCY,
           order: {
             orderUuid: labOrder.uuid,
-            orderUrgency: 'STAT',
-          },
-        }];
-        const store = mockStore({});
-        await store.dispatch(toggleDraftLabOrderUrgency(labOrder));
-        expect(store.getActions()).toEqual(expectedActions);
-        done();
-      });
+            orderUrgency: "STAT"
+          }
+        }
+      ];
+      const store = mockStore({});
+      await store.dispatch(toggleDraftLabOrderUrgency(labOrder));
+      expect(store.getActions()).toEqual(expectedActions);
+      done();
+    });
     it(`should dispatch TOGGLE_DRAFT_LAB_ORDER_URGENCY 
-    and set order urgency to ROUTINE if urgency was STAT`, async (done) => {
-        const labOrder = { uuid: 'abxzy-123', urgency: 'STAT' };
-        const expectedActions = [{
+    and set order urgency to ROUTINE if urgency was STAT`, async done => {
+      const labOrder = { uuid: "abxzy-123", urgency: "STAT" };
+      const expectedActions = [
+        {
           type: TOGGLE_DRAFT_LAB_ORDER_URGENCY,
           order: {
             orderUuid: labOrder.uuid,
-            orderUrgency: 'ROUTINE',
-          },
-        }];
-        const store = mockStore({});
-        await store.dispatch(toggleDraftLabOrderUrgency(labOrder));
-        expect(store.getActions()).toEqual(expectedActions);
-        done();
-      });
+            orderUrgency: "ROUTINE"
+          }
+        }
+      ];
+      const store = mockStore({});
+      await store.dispatch(toggleDraftLabOrderUrgency(labOrder));
+      expect(store.getActions()).toEqual(expectedActions);
+      done();
+    });
     it(`should dispatch TOGGLE_DRAFT_LAB_ORDER_URGENCY 
-    and set order urgency to STAT if urgency was ROUTINE`, async (done) => {
-        const labOrder = { uuid: 'abxzy-123', urgency: 'ROUTINE' };
-        const expectedActions = [{
+    and set order urgency to STAT if urgency was ROUTINE`, async done => {
+      const labOrder = { uuid: "abxzy-123", urgency: "ROUTINE" };
+      const expectedActions = [
+        {
           type: TOGGLE_DRAFT_LAB_ORDER_URGENCY,
           order: {
             orderUuid: labOrder.uuid,
-            orderUrgency: 'STAT',
-          },
-        }];
-        const store = mockStore({});
-        await store.dispatch(toggleDraftLabOrderUrgency(labOrder))
-        expect(store.getActions()).toEqual(expectedActions);
-        done();
-      });
+            orderUrgency: "STAT"
+          }
+        }
+      ];
+      const store = mockStore({});
+      await store.dispatch(toggleDraftLabOrderUrgency(labOrder));
+      expect(store.getActions()).toEqual(expectedActions);
+      done();
+    });
+  });
+
+  it("should dispatch DELETE_TEST_FROM_DRAFT_LAB_ORDER", async done => {
+    const order = {
+      display: "hermatocrite",
+      uuid: "2343564321"
+    };
+
+    const draftType = "single";
+    const expectedActions = {
+      type: DELETE_TEST_FROM_DRAFT_LAB_ORDER,
+      order
+    };
+
+    const store = mockStore({});
+    await store.dispatch(discardTestsInDraft({ order, draftType }));
+    expect(store.getActions()).toEqual([expectedActions]);
+    done();
+  });
+
+  it("should dispatch DELETE_PANEL_FROM_DRAFT_LAB_ORDER", async done => {
+    const order = {
+      display: "hermatocrite",
+      uuid: "2343564321"
+    };
+
+    const draftType = "panel";
+    const expectedActions = {
+      type: DELETE_PANEL_FROM_DRAFT_LAB_ORDER,
+      orders: order
+    };
+
+    const store = mockStore({});
+    await store.dispatch(discardTestsInDraft({ order, draftType }));
+    expect(store.getActions()).toEqual([expectedActions]);
+    done();
+  });
+
+  it("should dispatch DELETE_ALL_ITEMS_IN_DRAFT_LAB_ORDER", async done => {
+    const expectedActions = {
+      type: DELETE_ALL_ITEMS_IN_DRAFT_LAB_ORDER
+    };
+
+    const store = mockStore({});
+    await store.dispatch(discardTestsInDraft());
+    expect(store.getActions()).toEqual([expectedActions]);
+    done();
   });
 });


### PR DESCRIPTION
### **JIRA TICKET NAME**
[OEUI-239](https://issues.openmrs.org/browse/OEUI-239)

### **Summary**
- Users who add a drug or lab order should be able to discard the item.

## I have checked that on this Pull request

- [x] I can successfully create Drug orders
- [x] I can successfully create Lab orders
- [x] I can successfully search for drug orders
