### PR TITLE
OEUI-247: Implement Toast Message When Creating Drug Order

### DIFF
--- a/app/js/components/drugOrderEntry/addForm/AddForm.jsx
+++ b/app/js/components/drugOrderEntry/addForm/AddForm.jsx
@@ -10,6 +10,8 @@ import getOrderEntryConfigurations from '../../../actions/orderEntryActions';
 import { addDraftOrder } from '../../../actions/draftTableAction';
 import { selectDrugSuccess } from '../../../actions/drug';
 import { setOrderAction, setSelectedOrder } from '../../../actions/orderAction';
+import { successToast, errorToast } from '../../../utils/toast';
+import errorMessages from '../../../utils/errorMessages.json';
 
 export class AddForm extends React.Component {
   state = {
@@ -49,13 +51,19 @@ export class AddForm extends React.Component {
   }
 
   componentDidUpdate(prevProps) {
-    const { addedOrder } = this.props.addDrugOrderReducer;
+    const { status: { added, error }, errorMessage, addedOrder } = this.props.addDrugOrderReducer;
     if (addedOrder && prevProps.addDrugOrderReducer.addedOrder !== addedOrder) {
       this.props.setSelectedOrder({
         currentOrderType: {},
         order: null,
         activity: null,
       });
+    }
+    if (added && prevProps.addDrugOrderReducer.addedOrder !== addedOrder) {
+      successToast('Order Successfully Created');
+    }
+    if (error && prevProps.addDrugOrderReducer.errorMessage !== errorMessage) {
+      errorToast(errorMessages[errorMessage.join('')]);
     }
     return (
       Object.keys(this.props.draftOrder).length ||
@@ -368,7 +376,6 @@ const mapStateToProps = ({
   });
 
 AddForm.propTypes = {
-  addDrugOrderReducer: PropTypes.object.isRequired,
   clearSearchField: PropTypes.func.isRequired,
   selectDrugSuccess: PropTypes.func,
   setSelectedOrder: PropTypes.func.isRequired,
@@ -400,6 +407,11 @@ AddForm.propTypes = {
     currentProvider: PropTypes.shape({
       uuid: PropTypes.string,
     }),
+  }).isRequired,
+  addDrugOrderReducer: PropTypes.shape({
+    status: PropTypes.objectOf(PropTypes.bool),
+    errorMessage: PropTypes.string,
+    addedOrder: PropTypes.object,
   }).isRequired,
 };
 

--- a/app/js/reducers/addDrugOrderReducer.js
+++ b/app/js/reducers/addDrugOrderReducer.js
@@ -5,7 +5,11 @@ import {
 
 const initialState = {
   addedOrder: {},
-  error: null,
+  errorMessage: '',
+  status: {
+    error: false,
+    added: false,
+  },
 };
 
 const addDrugOrderReducer = (state = initialState, action) => {
@@ -14,11 +18,20 @@ const addDrugOrderReducer = (state = initialState, action) => {
       return {
         ...state,
         addedOrder: action.data,
+        errorMessage: '',
+        status: {
+          error: false,
+          added: true,
+        },
       };
     case POST_DRUG_ORDER_FAILURE:
       return {
         ...state,
-        error: action.payload,
+        errorMessage: action.payload.response.data.error.message,
+        status: {
+          error: true,
+          added: false,
+        },
       };
     default:
       return state;

--- a/app/js/utils/errorMessages.json
+++ b/app/js/utils/errorMessages.json
@@ -1,0 +1,3 @@
+{
+  "Order.cannot.have.more.than.one": "Cannot have more than one active order for the same orderable and care setting at same time"
+}

--- a/tests/components/DrugOrderEntry/addForm/AddForm.test.jsx
+++ b/tests/components/DrugOrderEntry/addForm/AddForm.test.jsx
@@ -2,7 +2,9 @@ import React from 'react';
 
 import { AddForm } from '../../../../app/js/components/drugOrderEntry/addForm/AddForm';
 
-const { draftOrders, draftOrder, editOrder, formType, session } = mockData;
+const {
+  draftOrders, draftOrder, editOrder, formType, session,
+} = mockData;
 
 const props = {
   addDraftOrder: jest.fn(),
@@ -15,13 +17,21 @@ const props = {
   setSelectedOrder: jest.fn(),
   getOrderEntryConfigurations: jest.fn(),
   allConfigurations: {
-    drugDosingUnits: [{display: 'grams'}],
-    orderFrequencies: [{display: 'daily'}],
-    drugRoutes: [{display: 'eye drops'}],
-    drugDispensingUnits: [{display: 'kits'}],
-    durationUnits:  [{display: 'months' }],
+    drugDosingUnits: [{ display: 'grams' }],
+    orderFrequencies: [{ display: 'daily' }],
+    drugRoutes: [{ display: 'eye drops' }],
+    drugDispensingUnits: [{ display: 'kits' }],
+    durationUnits: [{ display: 'months' }],
   },
-  careSetting: {bdisplay: 'Outpatient', uuid: 'aaa1234' },
+  addDrugOrderReducer: {
+    addedOrder: {},
+    errorMessage: '',
+    status: {
+      error: false,
+      added: false,
+    },
+  },
+  careSetting: { bdisplay: 'Outpatient', uuid: 'aaa1234' },
   drugName: 'Paracentamol',
   drugUuid: 'AJJJKW7378JHJ',
   draftOrder,
@@ -40,88 +50,120 @@ const getComponent = () => {
 };
 
 describe('Test for adding a new drug order', () => {
-    it('should render component', () => {
-      const wrapper = shallow(<AddForm {...props} />  );
-      expect(wrapper).toMatchSnapshot()
-    }); 
-   describe('Outpatient orders', () => {
-      const wrapper = mount(<AddForm {...props} />);
-      describe('Activate and deactivate Confirm button under standard dosing form', () => {
-        beforeEach(() => {
-          wrapper.find('[name="dose"]').simulate('change', {target: {name: 'dose', value: 8}});
-          wrapper.find('[name="dosingUnit"]').simulate('change', {target: {name: 'dosingUnit', value: 'kilogram'}});
-          wrapper.find('[name="route"]').simulate('change', {target: {name: 'route', value: 'oral'}});
-          wrapper.find('[name="frequency"]').simulate('change', {target: {name: 'frequency', value: 'once'}});
-          wrapper.find('[name="durationUnit"]').simulate('change', {target: {name: 'durationUnit', value: 'weeks'}});
-        });
-        it('should be deactivated without both dispensing quantity and units', () => {
-          expect(wrapper.find('button.confirm').props().disabled).toBe(true);
-        });
-        it('should be deactivated with dispensing quantity without units', () => {
-          wrapper.find('[name="dispensingQuantity"]').simulate('change', {target: {name: 'dispensingQuantity', value: 12}});
-          expect(wrapper.find('button.confirm').props().disabled).toBe(true);
-        });
-        it('should be activated with both dispensing Quantity and units', () => {
-          wrapper.find('[name="dispensingQuantity"]').simulate('change', {target: {name: 'dispensingQuantity', value: 12}});
-          wrapper.find('[name="dispensingUnit"]').simulate('change', {target: {name: 'dispensingUnit', value: 'kits'}});
-          expect(wrapper.find('button.confirm').props().disabled).toBe(false);
-        });
+  it('should render component', () => {
+    const wrapper = shallow(<AddForm {...props} />);
+    expect(wrapper).toMatchSnapshot();
+  });
+  describe('Outpatient orders', () => {
+    const wrapper = mount(<AddForm {...props} />);
+    describe('Activate and deactivate Confirm button under standard dosing form', () => {
+      beforeEach(() => {
+        wrapper.find('[name="dose"]').simulate('change', { target: { name: 'dose', value: 8 } });
+        wrapper
+          .find('[name="dosingUnit"]')
+          .simulate('change', { target: { name: 'dosingUnit', value: 'kilogram' } });
+        wrapper
+          .find('[name="route"]')
+          .simulate('change', { target: { name: 'route', value: 'oral' } });
+        wrapper
+          .find('[name="frequency"]')
+          .simulate('change', { target: { name: 'frequency', value: 'once' } });
+        wrapper
+          .find('[name="durationUnit"]')
+          .simulate('change', { target: { name: 'durationUnit', value: 'weeks' } });
       });
-      describe('Activate and deactivate Confirm button under free text form', () => {
-        it('should activate when the required fields are filled', () => {
-          wrapper.setState({ formType: 'Free Text' })
-          expect(wrapper.state().formType).toEqual('Free Text');
-          wrapper.find('[name="drugInstructions"]').simulate('change', {target: {name: 'drugInstructions', value: "3 tablets"}});
-          wrapper.find('[name="dispensingQuantity"]').simulate('change', {target: {name: 'dispensingQuantity', value: 12}});
-          wrapper.find('[name="dispensingUnit"]').simulate('change', {target: {name: 'dispensingUnit', value: 'kits'}});
-          expect(wrapper.find('button.confirm').props().disabled).toBe(false);
-        });
+      it('should be deactivated without both dispensing quantity and units', () => {
+        expect(wrapper.find('button.confirm').props().disabled).toBe(true);
       });
-      describe('Validation of fields', () => {
-        beforeEach(() => {
-          wrapper.find('[name="dispensingQuantity"]').simulate('change', {target: {name: 'dispensingQuantity', value: 12}});
-          wrapper.find('[name="dispensingUnit"]').simulate('change', {target: {name: 'dispensingUnit', value: 'tins'}});
-        });
-        it ('should deactivate confirm button with invalid dose units', () => {
-          wrapper.find('[name="dosingUnit"]').simulate('blur')
-          expect(wrapper.find('button.confirm').props().disabled).toBe(true);
-        });
-        it ('should display error with invalid dosing units', () => {
-          wrapper.find('[name="dosingUnit"]').simulate('blur')
-          expect(wrapper.find("span.field-error").length).toBe(1);
-        });
-        it ('should activate with valid dose units', () => {
-          wrapper.find('[name="dosingUnit"]').simulate('change', {target: {name: 'dosingUnit', value: 'grams'}});
-          wrapper.find('[name="dosingUnit"]').simulate('blur');
-          expect(wrapper.find('button.confirm').props().disabled).toBe(false);
-        });
-        it ('should deactivate with invalid frequency', () => {
-          wrapper.find('[name="frequency"]').simulate('blur');
-          expect(wrapper.find('button.confirm').props().disabled).toBe(true);
-        });
-        it ('should deactivate with invalid route', () => {
-          wrapper.find('[name="route"]').simulate('blur');
-          expect(wrapper.find('button.confirm').props().disabled).toBe(true);
-        });
-        it ('should deactivate with invalid dispensing unit', () => {
-          wrapper.find('[name="dispensingUnit"]').simulate('blur');
-          expect(wrapper.find('button.confirm').props().disabled).toBe(true);
-        });
-        it('should deactivate if duration is valid but duration unit is invalid', () => {
-          wrapper.find('[name="duration"]').simulate('change', {target: {name: 'duration', value: '1'}});
-          wrapper.find('[name="durationUnit"]').simulate('blur');
-          expect(wrapper.find('button.confirm').props().disabled).toBe(true);
-        });
+      it('should be deactivated with dispensing quantity without units', () => {
+        wrapper
+          .find('[name="dispensingQuantity"]')
+          .simulate('change', { target: { name: 'dispensingQuantity', value: 12 } });
+        expect(wrapper.find('button.confirm').props().disabled).toBe(true);
       });
+      it('should be activated with both dispensing Quantity and units', () => {
+        wrapper
+          .find('[name="dispensingQuantity"]')
+          .simulate('change', { target: { name: 'dispensingQuantity', value: 12 } });
+        wrapper
+          .find('[name="dispensingUnit"]')
+          .simulate('change', { target: { name: 'dispensingUnit', value: 'kits' } });
+        expect(wrapper.find('button.confirm').props().disabled).toBe(false);
+      });
+    });
+    describe('Activate and deactivate Confirm button under free text form', () => {
+      it('should activate when the required fields are filled', () => {
+        wrapper.setState({ formType: 'Free Text' });
+        expect(wrapper.state().formType).toEqual('Free Text');
+        wrapper
+          .find('[name="drugInstructions"]')
+          .simulate('change', { target: { name: 'drugInstructions', value: '3 tablets' } });
+        wrapper
+          .find('[name="dispensingQuantity"]')
+          .simulate('change', { target: { name: 'dispensingQuantity', value: 12 } });
+        wrapper
+          .find('[name="dispensingUnit"]')
+          .simulate('change', { target: { name: 'dispensingUnit', value: 'kits' } });
+        expect(wrapper.find('button.confirm').props().disabled).toBe(false);
+      });
+    });
+    describe('Validation of fields', () => {
+      beforeEach(() => {
+        wrapper
+          .find('[name="dispensingQuantity"]')
+          .simulate('change', { target: { name: 'dispensingQuantity', value: 12 } });
+        wrapper
+          .find('[name="dispensingUnit"]')
+          .simulate('change', { target: { name: 'dispensingUnit', value: 'tins' } });
+      });
+      it('should deactivate confirm button with invalid dose units', () => {
+        wrapper.find('[name="dosingUnit"]').simulate('blur');
+        expect(wrapper.find('button.confirm').props().disabled).toBe(true);
+      });
+      it('should display error with invalid dosing units', () => {
+        wrapper.find('[name="dosingUnit"]').simulate('blur');
+        expect(wrapper.find('span.field-error').length).toBe(1);
+      });
+      it('should activate with valid dose units', () => {
+        wrapper
+          .find('[name="dosingUnit"]')
+          .simulate('change', { target: { name: 'dosingUnit', value: 'grams' } });
+        wrapper.find('[name="dosingUnit"]').simulate('blur');
+        expect(wrapper.find('button.confirm').props().disabled).toBe(false);
+      });
+      it('should deactivate with invalid frequency', () => {
+        wrapper.find('[name="frequency"]').simulate('blur');
+        expect(wrapper.find('button.confirm').props().disabled).toBe(true);
+      });
+      it('should deactivate with invalid route', () => {
+        wrapper.find('[name="route"]').simulate('blur');
+        expect(wrapper.find('button.confirm').props().disabled).toBe(true);
+      });
+      it('should deactivate with invalid dispensing unit', () => {
+        wrapper.find('[name="dispensingUnit"]').simulate('blur');
+        expect(wrapper.find('button.confirm').props().disabled).toBe(true);
+      });
+      it('should deactivate if duration is valid but duration unit is invalid', () => {
+        wrapper
+          .find('[name="duration"]')
+          .simulate('change', { target: { name: 'duration', value: '1' } });
+        wrapper.find('[name="durationUnit"]').simulate('blur');
+        expect(wrapper.find('button.confirm').props().disabled).toBe(true);
+      });
+    });
   });
 });
 
 describe('Test AddForm state', () => {
   it('should update state', () => {
     mountedComponent = mount(<AddForm {...props} />);
-    getComponent().setState({fields:  { dose: 11}})
-    getComponent().find('[name="dose"]').simulate('change', {target: {name: 'dose', value: 9}});
-    getComponent().find('.confirm').simulate('click');
+    getComponent().setState({ fields: { dose: 11 } });
+    getComponent()
+      .find('[name="dose"]')
+      .simulate('change', { target: { name: 'dose', value: 9 } });
+    getComponent()
+      .find('.confirm')
+      .simulate('click');
     expect(getComponent().state().fields.dose).toEqual(9);
   });
 });
@@ -132,7 +174,7 @@ describe('handleFormType() method', () => {
     sinon.spy(renderedComponent, 'handleFormType');
     renderedComponent.handleFormType(formType);
     expect(renderedComponent.handleFormType.calledOnce).toEqual(true);
-    expect(getComponent().state('formType')).toEqual("Free Text");
+    expect(getComponent().state('formType')).toEqual('Free Text');
   });
 });
 
@@ -163,16 +205,16 @@ describe('populateEditOrderForm() method', () => {
     expect(renderedComponent.populateEditOrderForm.calledOnce).toEqual(true);
     expect(getComponent().state('activeTabIndex')).toEqual(1);
     expect(getComponent().state('fields')).toEqual({
-      dispensingQuantity: "",
-      dispensingUnit: "",
-      dose: "",
-      dosingUnit: "",
-      drugInstructions: "",
-      duration: "",
-      durationUnit: "",
-      frequency: "",
-      reason: "",
-      route: "",
+      dispensingQuantity: '',
+      dispensingUnit: '',
+      dose: '',
+      dosingUnit: '',
+      drugInstructions: '',
+      duration: '',
+      durationUnit: '',
+      frequency: '',
+      reason: '',
+      route: '',
     });
   });
 });
@@ -184,16 +226,16 @@ describe('clearDrugForms() method', () => {
     renderedComponent.clearDrugForms();
     expect(renderedComponent.clearDrugForms.calledOnce).toEqual(true);
     expect(getComponent().state('fields')).toEqual({
-      dispensingQuantity: "",
-      dispensingUnit: "",
-      dose: "",
-      dosingUnit: "",
-      drugInstructions: "",
-      duration: "",
-      durationUnit: "",
-      frequency: "",
-      reason: "",
-      route: "",
+      dispensingQuantity: '',
+      dispensingUnit: '',
+      dose: '',
+      dosingUnit: '',
+      drugInstructions: '',
+      duration: '',
+      durationUnit: '',
+      frequency: '',
+      reason: '',
+      route: '',
     });
   });
 });
@@ -205,25 +247,25 @@ describe('handleSubmitDrugForm() method', () => {
     renderedComponent.handleSubmitDrugForm();
     expect(renderedComponent.handleSubmitDrugForm.calledOnce).toEqual(true);
     expect(getComponent().state('draftOrder')).toEqual({
-      action: "NEW",
-      careSetting: "aaa1234",
-      dosingType: "org.openmrs.SimpleDosingInstructions",
-      drug: "AJJJKW7378JHJ",
-      drugName: "Paracentamol",
+      action: 'NEW',
+      careSetting: 'aaa1234',
+      dosingType: 'org.openmrs.SimpleDosingInstructions',
+      drug: 'AJJJKW7378JHJ',
+      drugName: 'Paracentamol',
       orderNumber: 1,
-      type: "drugorder",
-      orderer: "",
+      type: 'drugorder',
+      orderer: '',
       previousOrder: null,
-      dispensingQuantity: "",
-      dispensingUnit: "",
-      dose: "",
-      dosingUnit: "",
-      drugInstructions: "",
-      duration: "",
-      durationUnit: "",
-      frequency: "",
-      reason: "",
-      route: "",
+      dispensingQuantity: '',
+      dispensingUnit: '',
+      dose: '',
+      dosingUnit: '',
+      drugInstructions: '',
+      duration: '',
+      durationUnit: '',
+      frequency: '',
+      reason: '',
+      route: '',
     });
   });
   it('should call handleSubmitDrugForm()', () => {
@@ -232,15 +274,54 @@ describe('handleSubmitDrugForm() method', () => {
     component.setState({ action: 'NOT_NEW' });
     component.handleSubmitDrugForm();
     expect(hhhSpy).toHaveBeenCalledTimes(1);
-    expect(component.state.draftOrder).toEqual({ ...component.state.draftOrder, action: 'NOT_NEW', });
+    expect(component.state.draftOrder).toEqual({
+      ...component.state.draftOrder,
+      action: 'NOT_NEW',
+    });
   });
-  it('should change the selected order after a drug has been added', () =>{
+
+  it('displays a toast with message if a drug has been added successfully', () => {
+    expect(global.toastrMessage === 'Order Successfully Created').toBeFalsy();
+    const wrapper = getComponent();
+    wrapper.setProps({
+      ...wrapper.props(),
+      addDrugOrderReducer: {
+        errorMessage: '',
+        addedOrder: { id: 1, type: 'testorder' },
+        status: {
+          added: true,
+          error: false,
+        },
+      },
+    });
+    expect(global.toastrMessage).toEqual('Order Successfully Created');
+  });
+
+  it('displays a toast with message if a an error occured in adding drug', () => {
+    const wrapper = getComponent();
+    wrapper.setProps({
+      ...wrapper.props(),
+      addDrugOrderReducer: {
+        errorMessage: ["Order.cannot.have.more.than.one"],
+        addedOrder: {},
+        status: {
+          added: false,
+          error: true,
+        },
+      },
+    });
+    expect(global.toastrMessage).toEqual("Cannot have more than one active order for the same orderable and care setting at same time");
+  });
+
+  it('should change the selected order after a drug has been added', () => {
     const component = getComponent();
     props.setSelectedOrder.mockReset();
-    component.setProps({ 
-      addDrugOrderReducer: { addedOrder: {order: 'just-a-sample-order'} } 
+    component.setProps({
+      addDrugOrderReducer: {
+        addedOrder: { order: 'just-a-sample-order' },
+        status: { added: true, errror: false },
+      },
     });
     expect(props.setSelectedOrder).toHaveBeenCalledTimes(1);
   });
 });
-

--- a/tests/reducers/addDrugOrderReducer.test.js
+++ b/tests/reducers/addDrugOrderReducer.test.js
@@ -7,33 +7,47 @@ import addDrugOrderReducer from '../../app/js/reducers/addDrugOrderReducer';
 const addedOrder = mockData.addedOrder;
 const error = mockData.addedOrderError
 
-describe('addDrugOrderReducer reducer for post actions', () => {
+describe('addDrugOrderReducer reducer test-suite', () => {
     const initialState = {
         addedOrder: {},
-        error: null,
+        errorMessage: '',
+        status: {
+          error: false,
+          added: false,
+        },
       };
-    it('should return addedOrder payload', () => {
+    it(`parses payload from action to key addedOrder and sets status key 
+    added to true on POST_DRUG_ORDER_SUCCESS action type`, () => {
         const action = {
             type: POST_DRUG_ORDER_SUCCESS,
-            addedOrder,
+            data: { id: 1, type: 'drugorder'},
         }
-        const expected = {
-            addedOrder: addedOrder.response,
-            error: null,
+        const expectedState = {
+            ...initialState,
+            addedOrder: { id: 1, type: 'drugorder'},
+            status: {
+              error: false,
+              added: true,
+            }
         };
-        const newSate = addDrugOrderReducer(initialState, action);
-        expect(newSate).toEqual(expected);
+        const newState = addDrugOrderReducer(initialState, action);
+        expect(newState).toEqual(expectedState);
     });
-    it('should return an error', () => {
+    it(`parses payload error message from action to key errorMessage and
+    sets status key error to true on POST_DRUG_ORDER_FAILURE action type`, () => {
         const action = {
             type: POST_DRUG_ORDER_FAILURE,
-            error,
+            payload: { response: { data: { error: { message: 'Another error' }}}},
         }
-        const expected = {
-            addedOrder: {},
-            error: error.response,
+        const expectedState = {
+            ...initialState,
+            errorMessage: 'Another error',
+            status: {
+                error: true,
+                added: false,
+            }
         };
-        const newSate = addDrugOrderReducer(initialState, action);
-        expect(newSate).toEqual(expected);
+        const newState = addDrugOrderReducer(initialState, action);
+        expect(newState).toEqual(expectedState);
     });
 });


### PR DESCRIPTION
### **JIRA TICKET NAME**
[OEUI-247](https://issues.openmrs.org/browse/OEUI-247)

### **Summary**
-  Use toast messages to display server messages when creating a drug order.

## I have checked that on this Pull request

- [x] I can sucessfully create Drug orders
- [x] I can sucessfully create Lab orders
- [x] I can sucessfully search for drug orders
