### PR TITLE
OEUI-237: Discard a drug order from the draft list

### DIFF
--- a/app/js/actions/draftActions.js
+++ b/app/js/actions/draftActions.js
@@ -7,6 +7,7 @@ import {
   removeTestPanelFromDraft,
   deleteDraftLabOrder,
 } from '../actions/draftLabOrderAction';
+import { deleteAllDrugDraftOrders } from './draftTableAction';
 import constants from '../utils/constants';
 
 export const toggleDraftLabOrderUrgency = (order) => {
@@ -49,5 +50,7 @@ export const editDraftDrugOrder = order => (dispatch) => {
 export const discardTestsInDraft = (test = {}) => (dispatch) => {
   if (test.draftType === 'single') return dispatch(removeTestFromDraft(test.order));
   if (test.draftType === 'panel') return dispatch(removeTestPanelFromDraft(test.order));
-  return dispatch(deleteDraftLabOrder());
+  if (test.draftType === 'drugorder') return dispatch(deleteDraftOrder(test.order));
+  dispatch(deleteDraftLabOrder());
+  return dispatch(deleteAllDrugDraftOrders());
 };

--- a/app/js/actions/draftTableAction.js
+++ b/app/js/actions/draftTableAction.js
@@ -14,7 +14,7 @@ export const deleteDraftOrderSuccess = order => ({
   order,
 });
 
-export const deleteAllDraftOrdersSuccess = () => ({
+export const deleteAllDrugDraftOrdersSuccess = () => ({
   type: DELETE_ALL_DRAFT_DRUG_ORDERS_SUCCESS,
 });
 
@@ -26,6 +26,6 @@ export const deleteDraftOrder = order => (dispatch) => {
   dispatch(deleteDraftOrderSuccess(order));
 };
 
-export const deleteAllDraftOrders = () => (dispatch) => {
-  dispatch(deleteAllDraftOrdersSuccess());
+export const deleteAllDrugDraftOrders = () => (dispatch) => {
+  dispatch(deleteAllDrugDraftOrdersSuccess());
 };

--- a/app/js/components/Draft.jsx
+++ b/app/js/components/Draft.jsx
@@ -7,10 +7,21 @@ import IconButton from './button/IconButton';
 
 export class Draft extends PureComponent {
   renderDraftList = () => {
+    let draftType;
     const { draftOrders, handleDraftDiscard } = this.props;
     return draftOrders.map((order) => {
       const isPanel = !!order.set;
-      const draftType = !isPanel ? 'single' : 'panel';
+      const isOtherOrderType = !!order.type;
+
+      if (isPanel) {
+        draftType = 'panel';
+      } else {
+        draftType = 'single';
+      }
+      if (isOtherOrderType) {
+        draftType = order.type;
+      }
+
       const orderName = order.display || order.drugName;
       const iconClass = classNames(
         'scale',

--- a/tests/actions/draftActions.test.js
+++ b/tests/actions/draftActions.test.js
@@ -2,6 +2,7 @@ import {
   TOGGLE_DRAFT_LAB_ORDER_URGENCY,
   SET_SELECTED_ORDER,
   DELETE_DRAFT_DRUG_ORDER_SUCCESS,
+  DELETE_ALL_DRAFT_DRUG_ORDERS_SUCCESS,
   SELECT_DRUG,
   DELETE_TEST_FROM_DRAFT_LAB_ORDER,
   DELETE_PANEL_FROM_DRAFT_LAB_ORDER,
@@ -131,14 +132,33 @@ describe("Draft Actions", () => {
     done();
   });
 
-  it("should dispatch DELETE_ALL_ITEMS_IN_DRAFT_LAB_ORDER", async done => {
+  it("should dispatch DELETE_DRAFT_DRUG_ORDER_SUCCESS", async done => {
+    const order = {
+      drugName: "paracetamol",
+      drug: "23sdfert4356reg4321"
+    };
+
+    const draftType = "drugorder";
     const expectedActions = {
-      type: DELETE_ALL_ITEMS_IN_DRAFT_LAB_ORDER
+      type: DELETE_DRAFT_DRUG_ORDER_SUCCESS,
+      order: order
     };
 
     const store = mockStore({});
-    await store.dispatch(discardTestsInDraft());
+    await store.dispatch(discardTestsInDraft({ order, draftType }));
     expect(store.getActions()).toEqual([expectedActions]);
+    done();
+  });
+
+  it("should dispatch both DELETE_ALL_DRAFT_DRUG_ORDERS_SUCCESS and DELETE_ALL_ITEMS_IN_DRAFT_LAB_ORDER", async done => {
+    const expectedActions = [
+      { type: DELETE_ALL_ITEMS_IN_DRAFT_LAB_ORDER },
+      { type: DELETE_ALL_DRAFT_DRUG_ORDERS_SUCCESS }
+    ];
+
+    const store = mockStore({});
+    await store.dispatch(discardTestsInDraft());
+    expect(store.getActions()).toEqual(expectedActions);
     done();
   });
 });

--- a/tests/actions/draftTableAction.test.js
+++ b/tests/actions/draftTableAction.test.js
@@ -1,68 +1,65 @@
 import {
-  ADD_DRAFT_ORDER_SUCCESS,
-  DELETE_DRAFT_ORDER_SUCCESS,
-  DELETE_ALL_DRAFT_ORDERS_SUCCESS
+  ADD_DRAFT_DRUG_ORDER_SUCCESS,
+  DELETE_DRAFT_DRUG_ORDER_SUCCESS,
+  DELETE_ALL_DRAFT_DRUG_ORDERS_SUCCESS
 } from '../../app/js/actions/actionTypes';
 import {
   addDraftOrder,
   deleteDraftOrder,
-  deleteAllDraftOrders,
+  deleteAllDrugDraftOrders,
 } from '../../app/js/actions/draftTableAction';
 
 describe('Discontinue Order Actions', () => {
   beforeEach(() => moxios.install());
   afterEach(() => moxios.uninstall());
 
-  it('should dispatch a draft order successfuly', async (done) => {
+  it('should dispatch ADD_DRAFT_DRUG_ORDER_SUCCESS successfully', async (done) => {
     const order = {
       action: 'DISCONTINUE',
       drugName: 'panadol',
       orderNumber: 3
     };
 
-    const expectedActions = {
-      ADD_DRAFT_ORDER_SUCCESS,
+    const expectedActions = [{
+      type: ADD_DRAFT_DRUG_ORDER_SUCCESS,
       order,
-    }
+    }];
 
     const store = mockStore({});
 
-    await store.dispatch(addDraftOrder(order), () => {
-      expect(store.getActions()).toEqual(expectedActions);
-    });
+    await store.dispatch(addDraftOrder(order));
+    expect(store.getActions()).toEqual(expectedActions);
     done();
   });
 
-  it('should dispatch deleting a draft order successfuly', async (done) => {
+  it('should dispatch DELETE_DRAFT_DRUG_ORDER_SUCCESS successfully', async (done) => {
     const order = {
       action: 'DISCONTINUE',
       drugName: 'panadol',
       orderNumber: 3
     };
 
-    const expectedActions = {
-      DELETE_DRAFT_ORDER_SUCCESS,
+    const expectedActions = [{
+      type: DELETE_DRAFT_DRUG_ORDER_SUCCESS,
       order,
-    }
+    }];
 
     const store = mockStore({});
 
-    await store.dispatch(deleteDraftOrder(order), () => {
-      expect(store.getActions()).toEqual(expectedActions);
-    });
+    await store.dispatch(deleteDraftOrder(order));
+    expect(store.getActions()).toEqual(expectedActions);
     done();
   });
 
-  it('should dispatch deleting all draft orders successfuly', async (done) => {
-    const expectedActions = {
-      DELETE_ALL_DRAFT_ORDERS_SUCCESS,
-    }
+  it('should dispatch DELETE_ALL_DRAFT_DRUG_ORDERS_SUCCESS successfully', async (done) => {
+    const expectedActions = [{
+      type: DELETE_ALL_DRAFT_DRUG_ORDERS_SUCCESS,
+    }];
 
     const store = mockStore({});
 
-    await store.dispatch(deleteAllDraftOrders(), () => {
-      expect(store.getActions()).toEqual(expectedActions);
-    });
+    await store.dispatch(deleteAllDrugDraftOrders());
+    expect(store.getActions()).toEqual(expectedActions);
     done();
   });
 });


### PR DESCRIPTION
### **JIRA TICKET NAME**
[OEUI-237: Discard a drug order from the draft list](https://issues.openmrs.org/browse/OEUI-237)

### **Summary**
- Users who adds a drug order should be able to discard the item from the draft list when the "X" button is clicked

## I have checked that on this Pull request

- [x] I can successfully create Drug orders
- [x] I can successfully create Lab orders
- [x] I can successfully search for drug orders
