### PR TITLE
OEUI-215: Drafts List should be shared across order types

### DIFF
--- a/app/js/components/orderEntry/OrderEntryPage.jsx
+++ b/app/js/components/orderEntry/OrderEntryPage.jsx
@@ -14,6 +14,8 @@ import getDateFormat from '../../actions/dateFormat';
 import activeOrderAction from '../../actions/activeOrderAction';
 import { fetchPatientRecord, fetchPatientNote } from '../../actions/patient';
 import { setSelectedOrder } from '../../actions/orderAction';
+import { successToast, errorToast } from '../../utils/toast';
+import fetchLabOrders from '../../actions/labOrders/fetchLabOrders';
 import {
   editDraftDrugOrder,
   toggleDraftLabOrderUrgency,
@@ -33,6 +35,21 @@ export class OrderEntryPage extends PureComponent {
     this.props.getDateFormat('default');
     this.props.fetchPatientRecord(patientUuid);
     this.props.fetchPatientNote(patientUuid);
+  }
+
+  componentDidUpdate(prevProps, prevState) {
+    const {
+      status: { added, error },
+      errorMessage,
+      labOrderData,
+    } = this.props.createLabOrderReducer;
+    if (added && labOrderData !== prevProps.createLabOrderReducer.labOrderData) {
+      successToast('order successfully created');
+      this.props.fetchLabOrders(null, this.props.patient.uuid);
+    }
+    if (error) {
+      errorToast(errorMessage);
+    }
   }
 
   getUUID = (items, itemName) => items.find(item => item.display === itemName);
@@ -374,6 +391,12 @@ OrderEntryPage.propTypes = {
   toggleDraftLabOrderUrgency: PropTypes.func.isRequired,
   discardTestsInDraft: PropTypes.func.isRequired,
   createLabOrder: PropTypes.func.isRequired,
+  createLabOrderReducer: PropTypes.shape({
+    status: PropTypes.objectOf(PropTypes.bool),
+    errorMessage: PropTypes.string,
+    labOrderData: PropTypes.object,
+  }).isRequired,
+  fetchLabOrders: PropTypes.func.isRequired,
 };
 
 OrderEntryPage.defaultProps = {
@@ -415,6 +438,7 @@ const mapStateToProps = ({
   encounterRoleReducer: { encounterRole },
   encounterReducer: { encounterType },
   openmrs: { session },
+  createLabOrderReducer,
 }) => ({
   outpatientCareSetting,
   dateFormatReducer,
@@ -430,6 +454,7 @@ const mapStateToProps = ({
   encounterRole,
   session,
   configurations,
+  createLabOrderReducer,
 });
 
 const actionCreators = {
@@ -446,6 +471,7 @@ const actionCreators = {
   editDraftDrugOrder,
   discardTestsInDraft,
   createLabOrder,
+  fetchLabOrders,
 };
 
 const mapDispatchToProps = dispatch => bindActionCreators(actionCreators, dispatch);

--- a/tests/components/orderentry/OrderEntryPage.test.jsx
+++ b/tests/components/orderentry/OrderEntryPage.test.jsx
@@ -76,6 +76,14 @@ describe('Test for Order entry page when orderentryowa.encounterType is set', ()
         ],
       },
       draftDrugOrders: [{ drugName: 'paracetamol' }],
+      createLabOrderReducer: {
+        status: {
+          error: false,
+          added: true,
+        },
+        labOrderData: {},
+      },
+      fetchLabOrders: jest.fn(),
     };
     mountedComponent = undefined;
   });
@@ -175,6 +183,14 @@ describe('Test for Order entry page when orderentryowa.encounterType is not set'
         orders: [{ display: 'Hemoglobin', uuid: '12746hfgjff' }],
       },
       draftDrugOrders: [{ drugName: 'paracetamol' }],
+      createLabOrderReducer: {
+        status: {
+          error: false,
+          added: true,
+        },
+        labOrderData: {},
+      },
+      fetchLabOrders: jest.fn(),
     };
     mountedComponent = undefined;
   });
@@ -229,6 +245,14 @@ describe('Test for Order entry page when orderentryowa.encounterRole is set', ()
         orders: [{ display: 'Hemoglobin', uuid: '12746hfgjff' }],
       },
       draftDrugOrders: [{ drugName: 'paracetamol' }],
+      createLabOrderReducer: {
+        status: {
+          error: false,
+          added: true,
+        },
+        labOrderData: {},
+      },
+      fetchLabOrders: jest.fn(),
     };
     mountedComponent = undefined;
   });
@@ -271,6 +295,14 @@ describe('Test for Order entry page when orderentryowa.encounterRole is not set'
         orders: [{ display: 'Hemoglobin', uuid: '12746hfgjff' }],
       },
       draftDrugOrders: [{ drugName: 'paracetamol' }],
+      createLabOrderReducer: {
+        status: {
+          error: false,
+          added: true,
+        },
+        labOrderData: {},
+      },
+      fetchLabOrders: jest.fn(),
     };
     mountedComponent = undefined;
   });
@@ -322,6 +354,14 @@ describe('Test for Order entry page when orderentryowa.dateAndTimeFormat is set'
         orders: [{ display: 'Hemoglobin', uuid: '12746hfgjff' }],
       },
       draftDrugOrders: [{ drugName: 'paracetamol' }],
+      createLabOrderReducer: {
+        status: {
+          error: false,
+          added: true,
+        },
+        labOrderData: {},
+      },
+      fetchLabOrders: jest.fn(),
     };
     mountedComponent = undefined;
   });
@@ -364,6 +404,14 @@ describe('Test for Order entry page when orderentryowa.encounterRole is not set'
         orders: [{ display: 'Hemoglobin', uuid: '12746hfgjff' }],
       },
       draftDrugOrders: [{ drugName: 'paracetamol' }],
+      createLabOrderReducer: {
+        status: {
+          error: false,
+          added: true,
+        },
+        labOrderData: {},
+      },
+      fetchLabOrders: jest.fn(),
     };
     mountedComponent = undefined;
   });
@@ -434,6 +482,14 @@ describe('Handling Submit', () => {
       orders: [{ display: 'Hemoglobin', uuid: '12746hfgjff' }],
     },
     draftDrugOrders: [{ drugName: 'paracetamol', }],
+    createLabOrderReducer: {
+      status: {
+        error: false,
+        added: false,
+      },
+      labOrderData: { uuid: 'kjdhggf', display: 'order Entry', orders: [{ display: 'true' }] },
+    },
+    fetchLabOrders: jest.fn(),
   };
   const wrapper = shallow(<OrderEntryPage {...newProps} />);
 
@@ -449,6 +505,37 @@ describe('Handling Submit', () => {
     handleSubmit();
     expect(newProps.createLabOrder).toHaveBeenCalled();
   });
+
+  it('shows a toast prompt when test is submitted successfully', () => {
+    const component = getComponent();
+    component.setProps({
+      ...component.props(),
+      createLabOrderReducer: {
+        status: {
+          error: false,
+          added: true,
+        },
+        labOrderData: { uuid: 'kjdhggf', display: 'order Entry', orders: [{ display: 'true' }] },
+      },
+    });
+    expect(global.toastrMessage).toEqual('order successfully created');
+  });
+});
+
+it('shows a toast prompt when there is an error in submission', () => {
+  const component = getComponent();
+  component.setProps({
+    ...component.props(),
+    createLabOrderReducer: {
+      status: {
+        error: true,
+        added: false,
+      },
+      labOrderData: {},
+      errorMessage: 'an error occured',
+    },
+  });
+  expect(global.toastrMessage).toEqual('an error occured');
 });
 
 describe('Connected OrderEntryPage component', () => {
@@ -508,6 +595,14 @@ describe('Connected OrderEntryPage component', () => {
         },
         draftDrugOrders: [{ drugName: 'paracetamol' }],
       },
+      createLabOrderReducer: {
+        status: {
+          error: false,
+          added: true,
+        },
+        labOrderData: {},
+      },
+      fetchLabOrders: jest.fn(),
     });
     const props = {
       location: { search: '?patient=esere_shbfidfb_343ffd' },


### PR DESCRIPTION
### **JIRA TICKET NAME**
[OEUI-215](https://issues.openmrs.org/browse/OEUI-215)

### **Summary**
- The drafts list should be moved to the right side of the page and be slightly separated visually from the Lab Order and Med Order entry panes.  The list should remain on the page as the user switches between the Lab and Drug pages.

## I have checked that on this Pull request

- [x] I can successfully create Drug orders
- [x] I can successfully create Lab orders
- [x] I can successfully search for drug orders
