### PR TITLE
OEUI-263: Add order from sets to order types

### DIFF
--- a/app/js/components/orderEntry/RenderOrderType.jsx
+++ b/app/js/components/orderEntry/RenderOrderType.jsx
@@ -19,6 +19,9 @@ const RenderOrderType = (props) => {
         />
       );
     }
+    case orderTypes.ORDER_FROM_SETS.id: {
+      return "<InsertComponent />";
+    }
     default: {
       return (<AllOrders />);
     }

--- a/app/js/components/orderEntry/SortAndFilter.jsx
+++ b/app/js/components/orderEntry/SortAndFilter.jsx
@@ -14,6 +14,7 @@ export const SortAndFilter = props => (
         <option value="all">All</option>
         <option value="drugorder">Drug Orders</option>
         <option value="testorder">Test Orders</option>
+        <option value="orderset">Order from Sets</option>
       </select>
     </div>
     {/* The .sort-status element and it's children is currently hidden from the view

--- a/app/js/components/orderEntry/orderTypes.js
+++ b/app/js/components/orderEntry/orderTypes.js
@@ -1,2 +1,3 @@
 export const DRUG_ORDER = { id: 1, text: 'Drug Orders' };
 export const LAB_ORDER = { id: 2, text: 'Lab Orders' };
+export const ORDER_FROM_SETS = { id: 3, text: 'Order From Sets' };

--- a/app/js/components/orderEntry/styles.scss
+++ b/app/js/components/orderEntry/styles.scss
@@ -73,7 +73,7 @@
   }
 
   .order-type-option {
-    font-size: 18px;
+    font-size: 14px;
     font-weight: 300;
     cursor: pointer;
     padding: 5px 10px;


### PR DESCRIPTION
### **JIRA TICKET NAME**
[OEUI-263 Add order from sets to order types ](https://issues.openmrs.org/browse/OEUI-263)

### **Summary**
- Add order from sets to order types so that it displays in order type dropdown

## I have checked that on this Pull request

- [x] I can successfully create Drug orders
- [x] I can successfully create Lab orders
- [x] I can successfully search for drug orders
