### PR TITLE
OEUI-263: Add order from set to order types

### DIFF
--- a/app/js/components/orderEntry/RenderOrderType.jsx
+++ b/app/js/components/orderEntry/RenderOrderType.jsx
@@ -19,6 +19,9 @@ const RenderOrderType = (props) => {
         />
       );
     }
+    case orderTypes.ORDER_FROM_SETS.id: {
+      return "<InsertComponent />";
+    }
     default: {
       return (<AllOrders />);
     }

--- a/app/js/components/orderEntry/orderTypes.js
+++ b/app/js/components/orderEntry/orderTypes.js
@@ -1,2 +1,3 @@
 export const DRUG_ORDER = { id: 1, text: 'Drug Orders' };
 export const LAB_ORDER = { id: 2, text: 'Lab Orders' };
+export const ORDER_FROM_SETS = { id: 3, text: 'Order From Sets' };

--- a/app/js/components/orderEntry/styles.scss
+++ b/app/js/components/orderEntry/styles.scss
@@ -73,7 +73,7 @@
   }
 
   .order-type-option {
-    font-size: 18px;
+    font-size: 14px;
     font-weight: 300;
     cursor: pointer;
     padding: 5px 10px;

--- a/tests/components/orderentry/RenderOrderType.test.jsx
+++ b/tests/components/orderentry/RenderOrderType.test.jsx
@@ -37,5 +37,10 @@ describe('Component: orderentry: RenderOrderType', () => {
       const component = getComponent();
       expect(component).toMatchSnapshot();
     });
+    it('shows the order from set entry when specified', () => {
+      props.currentOrderTypeID = orderTypes.ORDER_FROM_SETS.id;
+      const component = getComponent();
+      expect(component).toMatchSnapshot();
+    });
   });
 });

--- a/tests/components/orderentry/SelectOrderType.test.jsx
+++ b/tests/components/orderentry/SelectOrderType.test.jsx
@@ -21,7 +21,7 @@ describe('Component: orderentry: SelectOrderType', () => {
   });
   it('should render two dropdown type navs', () => {
     const component = getComponent();
-    expect(component.find('.order-type-option').length).toBe(2);
+    expect(component.find('.order-type-option').length).toBe(3);
   });
   it('the current order type should have a border styling', () => {
     const component = getComponent();


### PR DESCRIPTION
### **JIRA TICKET NAME**
[OEUI-263 Add order from sets to order types ](https://issues.openmrs.org/browse/OEUI-263)

### **Summary**
- Add order from sets to order types so that it displays in order type drop-down

## I have checked that on this Pull request

- [x] I can successfully create Drug orders
- [x] I can successfully create Lab orders
- [x] I can successfully search for drug orders
