### PR TITLE
OEUI-279: Fix order list pagination showing NAN

### DIFF
--- a/app/js/components/orderEntry/Paginate.jsx
+++ b/app/js/components/orderEntry/Paginate.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+
 const Paginate = ({
   totalPage,
   nextPageUrl,
@@ -10,16 +11,26 @@ const Paginate = ({
   patientId,
 }) => (
   <div className="pagination">
-    <div
-      className="page-link prev"
-      value="previous"
-      onClick={() => dispatch(fetchNew(prevPageUrl, patientId))}
-      role="button"
-      tabIndex={0}>
-      <p>❮❮</p>
-    </div>
+    { totalPage > 10 ?
+      <div
+        className="page-link prev"
+        value="previous"
+        onClick={() => dispatch(fetchNew(prevPageUrl, patientId))}
+        role="button"
+        tabIndex={0}>
+        <p>❮❮</p>
+      </div>
+      :
+      <div
+        className="page-link-disabled"
+        value="previous"
+        role="button"
+        tabIndex={0}>
+        <p>❮❮</p>
+      </div>
+    }
     <div className="page-link">
-      <p>{Math.floor(nextPageUrl.split('=')[7] / 10)}</p>
+      <p>{prevPageUrl ? Math.floor(prevPageUrl.split('=')[8] / 10) : '1' }</p>
     </div>
     <div className="page-link no-click">
       <p>/</p>

--- a/app/js/components/orderEntry/styles.scss
+++ b/app/js/components/orderEntry/styles.scss
@@ -220,6 +220,22 @@
   cursor: pointer;
 }
 
+.page-link-disabled {
+  color: black;
+  float: left;
+  padding: 8px 16px;
+  text-decoration: none;
+  transition: background-color 0.3s;
+  border: 1px solid #ddd;
+  p {
+    color: #007fff !important;
+  }
+}
+
+.page-link-disabled:hover {
+  background-color: rgba(0,0,0,0.1);
+}
+
 .current-page {
   background-color: #999;
 }

--- a/tests/components/orderentry/Paginate.test.jsx
+++ b/tests/components/orderentry/Paginate.test.jsx
@@ -10,11 +10,25 @@ const props = {
   fetchNew: jest.fn(),
 }
 
+const props2 = {
+  totalPage: 5,
+  nextPageUrl: 'http://next=page=some=random=page=and=the=length=20',
+  dispatch: jest.fn(),
+  prevPageUrl: '',
+  patientId: '123eeeeeer',
+  fetchNew: jest.fn(),
+}
+
+const wrapper2 = shallow(<Paginate {...props2} />)
 const wrapper = shallow(<Paginate {...props} />)
 
 describe('Pagination component test-suite', () => {
   it('renders properly', () => {
     expect(wrapper).toMatchSnapshot();
+  });
+
+  it('Should render pagination component when no previousurl is passed', () => {
+    expect(wrapper2).toMatchSnapshot();
   });
 
   it('dispatches action to fetch new data when the next button is clicked', () => {


### PR DESCRIPTION
### **JIRA TICKET NAME**
[OEUI-279 Order List page number showing as "NaN"](https://issues.openmrs.org/browse/OEUI-279) 

### **Summary**
- Fix Order list pagination showing NAN
- Disable the previous button if the total order is less than ten.

## I have checked that on this Pull request

- [x] I can successfully create Drug orders
- [x] I can successfully create Lab orders
- [x] I can successfully search for drug orders
