### PR TITLE
OEUI-282: (New) and (Revise) should not appear on order list

### DIFF
--- a/app/js/components/orderEntry/OrdersTable.jsx
+++ b/app/js/components/orderEntry/OrdersTable.jsx
@@ -163,35 +163,38 @@ export class OrdersTable extends PureComponent {
       <React.Fragment>
         {filteredOrders &&
           filteredOrders.length !== 0 &&
-          filteredOrders.map(order => (
-            <Accordion
-              title={
-                <OrderHeader
-                  status="Active"
-                  orderable={order.display}
-                  order={order}
-                  handleEdit={this.handleActiveOrderEdit}
-                  handleDiscontinue={this.setDiscontinuedDrugOrder}
-                />
-              }
-              key={order.uuid}
-              dateFormat={dateFormat}
-              date={order.dateActivated}>
-              {order.type === 'drugorder' ? (
-                <DrugOrderDetails
-                  dosingInstructions={order.dosingInstructions}
-                  dispense={order.dispense}
-                  activeDates={format(order.dateActivated, dateFormat)}
-                  orderer={order.orderer.display.split('-')[1]}
-                />
-              ) : (
-                <LabOrderDetails
-                  urgency={order.urgency}
-                  orderer={order.orderer.display.split('-')[1]}
-                />
-              )}
-            </Accordion>
-          ))}
+          filteredOrders.map((order) => {
+            const { drug, display } = order;
+            return (
+              <Accordion
+                title={
+                  <OrderHeader
+                    status="Active"
+                    orderable={drug ? drug.display : display}
+                    order={order}
+                    handleEdit={this.handleActiveOrderEdit}
+                    handleDiscontinue={this.setDiscontinuedDrugOrder}
+                  />
+                }
+                key={order.uuid}
+                dateFormat={dateFormat}
+                date={order.dateActivated}>
+                {order.type === 'drugorder' ? (
+                  <DrugOrderDetails
+                    dosingInstructions={order.dosingInstructions}
+                    dispense={order.dispense}
+                    activeDates={format(order.dateActivated, dateFormat)}
+                    orderer={order.orderer.display.split('-')[1]}
+                  />
+                ) : (
+                  <LabOrderDetails
+                    urgency={order.urgency}
+                    orderer={order.orderer.display.split('-')[1]}
+                  />
+                )}
+              </Accordion>
+            );
+          })}
         {this.renderNoFilterResults()}
       </React.Fragment>
     );

--- a/tests/components/orderentry/OrdersTable.test.jsx
+++ b/tests/components/orderentry/OrdersTable.test.jsx
@@ -49,6 +49,10 @@ const props = {
       dosingInstructions: '25mg of Amoxycillin syrup for the next 5 days',
       dispense: '45',
       orderer: { display: 'Mark Goodrich' },
+      drug: {
+        uuid: "502a2b2e-4659-4987-abbd-c50545dead47",
+        display: "Paracetamol",
+      },
       urgency: 'STAT',
       uuid: 2,
     },
@@ -57,6 +61,10 @@ const props = {
       display: 'Paracetamol',
       type: 'testorder',
       orderer: { display: 'Mark Goodrich' },
+      drug: {
+        uuid: "502a2b2e-4659-4987-abbd-c50545dead47",
+        display: "Paracetamol",
+      },
       urgency: 'STAT',
       uuid: 2,
     },


### PR DESCRIPTION
### **JIRA TICKET NAME**
[OEUI-282: (New) and (Revise) should not appear on order list](https://issues.openmrs.org/browse/OEUI-282)

### **Summary**
- Remove (New) and (Revise) from the order list
- New and Revise should show on draft list

## I have checked that on this Pull request

- [x] I can sucessfully create Drug orders
- [x] I can sucessfully create Lab orders
- [x] I can sucessfully search for drug orders
