### PR TITLE
OEUI-278: Rename Order Entry app from "openmrs-owa-orderentry" to "orderentry"

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Create a config.json file in the top level directory following this template:
 
 {
     'LOCAL_OWA_FOLDER': '/Users/name/openmrs-standalone-2.4/appdata/owa/',
-    'APP_ENTRY_POINT': 'http://localhost:8081/openmrs-standalone/owa/openmrs-owa-orderentry/index.html'
+    'APP_ENTRY_POINT': 'http://localhost:8081/openmrs-standalone/owa/orderentry/index.html'
 }
 
 "LOCAL_OWA_FOLDER" should point to the "owa" directory of your locally running OpenMRS instance, and

--- a/app/index.html
+++ b/app/index.html
@@ -2,7 +2,7 @@
 <html>
 
 <head>
-  <title>openmrs-owa-orderentry</title>
+  <title>orderentry</title>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no">
   <!-- openmrs favicon -->

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "openmrs-owa-orderentry",
+  "name": "orderentry",
   "version": "1.0.0-beta3",
   "description": "It is designed to address a set of specific use cases – e.g., placing an order, revising it, discontinuing it, and being able to look up a patient&#39;s active orders.",
   "repository": {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -25,7 +25,7 @@ const autoprefixer = require('autoprefixer');
 
 const env = process.env.NODE_ENV;
 
-const THIS_APP_ID = 'openmrs-owa-orderentry';
+const THIS_APP_ID = 'orderentry';
 
 var plugins = [];
 const nodeModules = {};


### PR DESCRIPTION
### **JIRA TICKET NAME**
[OEUI-278: Rename Order Entry app from "openmrs-owa-orderentry" to "orderentry" ](https://issues.openmrs.org/browse/OEUI-278)


### **Summary**
- I renamed the app from "openmrs-owa-orderentry" to "orderentry" 
- The deployed artefact was changed from "openmrs-owa-orderentry.zip" to "orderentry.zip" 
- The title of the index.html file was changed to `orderentry`
- The package.json name was changed to `orderentry`
- The weback.config.js, config.json and package.json were edited accordingly. 


## I have checked that on this Pull request

- [x] I can successfully create Drug orders
- [x] I can successfully create Lab orders
- [x] I can successfully search for drug orders
