### PR TITLE
OEUI-269: Cancel Order Set Action

### DIFF
--- a/app/js/components/setsOrderEntry/OrderSetForm.jsx
+++ b/app/js/components/setsOrderEntry/OrderSetForm.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import SelectBox from '../selectBox';
 import Accordion from '../orderEntry/Accordion';
-import OrderHeader from '../orderEntry/OrderHeader';
 import OrderSetDetails from './OrderSetDetails';
 import './styles.scss';
 
@@ -13,12 +12,16 @@ class OrderSetForm extends PureComponent {
     items: [{ value: 'Choose a set to add', id: 0 }, { value: 'Mineral', id: 1 }],
     selectedItem: '',
     isDisabled: false,
-    displaySets: 'block',
-    displayForm: 'none',
+    displaySets: true,
+    displayForm: false,
   }
 
   changeSelectedOrderSet = () => {
-    this.setState({ displaySets: 'none', displayForm: 'block' });
+    this.setState({ displaySets: false, displayForm: true });
+  }
+
+  cancelOrderSet = () => {
+    this.setState({ displaySets: true, displayForm: false });
   }
 
   render() {
@@ -31,30 +34,23 @@ class OrderSetForm extends PureComponent {
           <div>
             <h1>Order from Sets</h1>
           </div>
-          <span style={{ display: displaySets }}>
+          <span style={{ display: displaySets ? 'block' : 'none' }}>
             <SelectBox
               items={items}
               selectedItem={selectedItem}
               onChange={this.changeSelectedOrderSet}
             />
           </span>
-          <span style={{ display: displayForm }}>
+          <span style={{ display: displayForm ? 'block' : 'none' }}>
             <div className="set-header">
               <h1>DIABETES INITIAL WORKUP</h1>
             </div>
             <table>
               <tbody>
                 <tr className="set-details">
-                  <th className="set-details-header">Details</th>
-                  <th className="set-actions-header">Actions</th>
+                  <th colSpan="2" className="set-details-header">Details</th>
                 </tr>
                 <Accordion
-                  title={
-                    <OrderHeader
-                      handleEdit={() => {}}
-                      handleDiscontinue={() => {}}
-                    />
-                  }
                   key={1}
                   caretText="Test Set"
                 >
@@ -66,7 +62,7 @@ class OrderSetForm extends PureComponent {
             <input
               type="button"
               id="draft-discard-all"
-              onClick={() => {}}
+              onClick={this.cancelOrderSet}
               className="button cancel modified-btn"
               value="Cancel"
               disabled={isDisabled}

--- a/tests/components/setOrderEntry/OrderSetForm.test.jsx
+++ b/tests/components/setOrderEntry/OrderSetForm.test.jsx
@@ -26,6 +26,13 @@ describe('Component: OrderSetForm', () => {
     const renderedComponent = getComponent().instance();
     const { changeSelectedOrderSet } = renderedComponent;
     changeSelectedOrderSet();
-    expect(renderedComponent.state.displaySets).toEqual('none');
+    expect(renderedComponent.state.displaySets).toEqual(false);
+  });
+
+  it('should hide the segment of the form that displays the order details when cancelOrderSet is called', () => {
+    const renderedComponent = getComponent().instance();
+    const { cancelOrderSet } = renderedComponent;
+    cancelOrderSet();
+    expect(renderedComponent.state.displayForm).toEqual(false);
   });
 });


### PR DESCRIPTION
### **JIRA TICKET NAME**
[OEUI-269: Cancel Order Set Action](https://issues.openmrs.org/browse/OEUI-269)

### **Summary**
- When the cancel button is clicked, user should be returned to the select dropdown view
- The edit and delete action buttons should also be removed

## I have checked that on this Pull request

- [x] I can sucessfully create Drug orders
- [x] I can sucessfully create Lab orders
- [x] I can sucessfully search for drug orders
