### PR TITLE
OEUI-288: Extend secondary header on the page

### DIFF
--- a/app/js/components/orderEntry/styles.scss
+++ b/app/js/components/orderEntry/styles.scss
@@ -362,3 +362,7 @@
     }
   }
 }
+
+.patient-header {
+  margin: 10px 0px;
+}


### PR DESCRIPTION
### **JIRA TICKET NAME**
[OEUI-288: Extend secondary header on the page](https://issues.openmrs.org/browse/OEUI-288)

### **Summary**
- The white space does not extend to the edge of the usable space on the page. This PR aim was to fix the issue.

## I have checked that on this Pull request

- [x] I can successfully create Drug orders
- [x] I can successfully create Lab orders
- [x] I can successfully search for drug orders
