### PR TITLE
UHM-5495 and OEUI-294 : Stand alone lab order flow

### DIFF
--- a/app/js/actions/createOrder.js
+++ b/app/js/actions/createOrder.js
@@ -3,9 +3,10 @@ import axiosInstance from '../config';
 
 import { SAVE_DRAFT_LAB_ORDER } from './actionTypes';
 
-const createOrder = OrderData => ({
+const createOrder = (OrderData, returnUrl) => ({
   type: SAVE_DRAFT_LAB_ORDER,
   payload: axiosInstance.post(`encounter`, OrderData),
+  meta: { returnUrl },
 });
 
 export default createOrder;

--- a/app/js/middlewares/responseHandlerMiddleware.js
+++ b/app/js/middlewares/responseHandlerMiddleware.js
@@ -69,6 +69,9 @@ export default function responseHandlerMiddleware() {
       next({
         type: 'SET_SELECTED_ORDER', currentOrderType: {}, selectedorder: {}, activity: {},
       });
+      if (action.meta.returnUrl) {
+        window.location.href = action.meta.returnUrl;
+      }
     }
 
     if (action.payload) {

--- a/app/js/reducers/initialState.js
+++ b/app/js/reducers/initialState.js
@@ -119,7 +119,9 @@ export default {
   labOrderables: {
     error: false,
     loading: false,
-    orderables: [{}],
+    orderables: [{
+      uuid: '',
+    }],
   },
   labConcepts: {
     error: null,

--- a/tests/components/orderentry/OrderEntryPage.test.jsx
+++ b/tests/components/orderentry/OrderEntryPage.test.jsx
@@ -87,6 +87,11 @@ describe('Test for Order entry page when orderentryowa.encounterType is set', ()
         labOrderData: {},
       },
       fetchLabOrders: jest.fn(),
+      labOrderableReducer: {
+        orderables: [{
+          uuid: '1234'
+        }]
+      }
     };
     mountedComponent = undefined;
   });
@@ -340,6 +345,11 @@ describe('Connected OrderEntryPage component', () => {
         labOrderData: {},
       },
       fetchLabOrders: jest.fn(),
+      labOrderableReducer: {
+        orderables: [{
+          uuid: '1234'
+        }]
+      }
     });
     const wrapper = shallow(<ConnectedOrderEntryPage store={store} {...props} />);
     expect(wrapper.length).toBe(1);

--- a/tests/middlewares/responseHandlerMiddleware.test.js
+++ b/tests/middlewares/responseHandlerMiddleware.test.js
@@ -173,7 +173,10 @@ describe('responseHandlerMiddleware', () => {
   });
   it('should dispatch SAVE_DRAFT_LAB_ORDER_SUCCESS',() => {
       const action = {
-        type: 'SAVE_DRAFT_LAB_ORDER_SUCCESS'
+        type: 'SAVE_DRAFT_LAB_ORDER_SUCCESS',
+        meta: {
+            returnUrl: 'mockUrl'
+        }
       }
       nextArgs = [],
       nextHandler(fakeNext)(action);


### PR DESCRIPTION
### **JIRA TICKET NAME**
[UHM-3495](https://tickets.pih-emr.org/browse/UHM-3495)
[OEUI-294](https://issues.openmrs.org/browse/OEUI-294)

### **Summary**
- This PR allows you open the app in either lab orders page or drug order page. it also allows you set a return URL when you sign or save draft orders
### **Usage** 

?patient=da5e210f-a3c4-4c49-80f2-e2e5386db8ad&page=Lab%20Orders&returnurl=https://www.google.com/#
just add a `page` and `returnurl` as part of the query string.

## I have checked that on this Pull request

- [x ] I can sucessfully create Drug orders
- [x ] I can sucessfully create Lab orders
- [x ] I can sucessfully search for drug orders