### PR TITLE
OEUI-293: Enforce prop-type validation in all components

### DIFF
--- a/app/js/components/orderEntry/OrderEntryPage.jsx
+++ b/app/js/components/orderEntry/OrderEntryPage.jsx
@@ -371,6 +371,9 @@ OrderEntryPage.propTypes = {
     uuid: PropTypes.string,
     display: PropTypes.string,
   }),
+  labOrderableReducer: PropTypes.shape({
+    orderables: PropTypes.arrayOf(PropTypes.object),
+  }),
   settingEncounterTypeReducer: PropTypes.shape({
     error: PropTypes.string,
     isLoading: PropTypes.bool,
@@ -428,6 +431,10 @@ OrderEntryPage.propTypes = {
 OrderEntryPage.defaultProps = {
   configurations: {},
   outpatientCareSetting: null,
+  labOrderableReducer: {
+    error: false,
+    orderables: [],
+  },
   settingEncounterRoleReducer: null,
   settingEncounterTypeReducer: null,
   dateFormatReducer: null,

--- a/app/js/components/orderEntry/RenderOrderType.jsx
+++ b/app/js/components/orderEntry/RenderOrderType.jsx
@@ -26,3 +26,25 @@ const RenderOrderType = (props) => {
 };
 
 export default RenderOrderType;
+
+RenderOrderType.defaultProps = {
+  outpatientCareSetting: null,
+  inpatientCareSetting: {
+    uuid: '',
+  },
+};
+
+RenderOrderType.propTypes = {
+  currentOrderTypeID: PropTypes.number,
+  outpatientCareSetting: PropTypes.shape({
+    uuid: PropTypes.string,
+    display: PropTypes.string,
+  }),
+  inpatientCareSetting: PropTypes.shape({
+    uuid: PropTypes.string,
+    display: PropTypes.string,
+  }),
+  location: PropTypes.shape({
+    search: PropTypes.string,
+  }),
+};


### PR DESCRIPTION
### **JIRA TICKET NAME**
[OEUI-293: Enforce prop-type validation in all components](https://issues.openmrs.org/browse/OEUI-293)

### **Summary**
- Some components do not have prop-type validation present, the goal of this ticket is to locate such components and add prop-type validations.

## I have checked that on this Pull request

- [x] I can successfully create Drug orders
- [x] I can successfully create Lab orders
- [x] I can successfully search for drug orders
