### PR TITLE
UHM-3495: Hide selectOrderTypes

### DIFF
--- a/app/js/components/orderEntry/OrderEntryPage.jsx
+++ b/app/js/components/orderEntry/OrderEntryPage.jsx
@@ -209,6 +209,7 @@ export class OrderEntryPage extends PureComponent {
       settingEncounterTypeReducer,
       dateFormatReducer,
     } = this.props;
+    const { page } = this.state;
     const { settingEncounterType, error } = settingEncounterTypeReducer;
     const { settingEncounterRole, roleError } = settingEncounterRoleReducer;
     const { dateFormat, error: dateError } = dateFormatReducer;
@@ -315,10 +316,10 @@ export class OrderEntryPage extends PureComponent {
                   <b>Orders List</b>
                 </h3>
               </div>
-              <SelectOrderType
+              {!(page) && <SelectOrderType
                 switchOrderType={this.switchOrderType}
                 currentOrderType={this.props.currentOrderType}
-              />
+              />}
             </div>
             <div className="body-wrapper drug-order-entry">
               <RenderOrderType


### PR DESCRIPTION
### **JIRA TICKET NAME**
[UHM-3495](https://tickets.pih-emr.org/browse/UHM-3495)
[OEUI-294](https://issues.openmrs.org/browse/OEUI-294)

### **Summary**
- This PR hides the menu that allows users to switch to drug orders when you navigate to the page from the patient-dashboard

## I have checked that on this Pull request

- [x] I can sucessfully create Drug orders
- [x] I can sucessfully create Lab orders
- [x] I can sucessfully search for drug orders
