### PR TITLE
OEUI-297: Fix PropTypes import error OrderEntryPage.jsx file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ coverage
 .idea
 *.swp
 *.swo
+tags
+tags.lock
+tags.temp

--- a/app/js/components/orderEntry/RenderOrderType.jsx
+++ b/app/js/components/orderEntry/RenderOrderType.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import DrugOrderEntry from '../drugOrderEntry';
 import * as orderTypes from './orderTypes';
 import LabEntryForm from '../labOrderEntry/LabEntryForm';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "openmrs-owa-orderentry",
+  "name": "orderentry",
   "version": "1.0.0-beta3",
   "lockfileVersion": 1,
   "requires": true,


### PR DESCRIPTION
### **JIRA TICKET NAME**
[OEUI-297: Fix PropTypes import error OrderEntryPage.jsx file](https://issues.openmrs.org/browse/OEUI-297) 

### **Summary**
- Fixed by imorting `PropTypes` in the `OrderEntryPage` component.

## I have checked that on this Pull request

- [x] I can sucessfully create Drug orders
- [x] I can sucessfully create Lab orders
- [x] I can sucessfully search for drug orders
