### PR TITLE
OEUI-300: Browser Tab Heading/Title should read "OpenMRS Electronic Medical Record"

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -2,7 +2,7 @@
 <html>
 
 <head>
-  <title>orderentry</title>
+  <title>OpenMRS Electronic Medical Record</title>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no">
   <!-- openmrs favicon -->


### PR DESCRIPTION
### **JIRA TICKET NAME**
[OEUI-300](https://issues.openmrs.org/browse/OEUI-300) Browser Tab Heading/Title should read "OpenMRS Electronic Medical Record"

### **Summary**
- changed app title from orderentry to OpenMRS Electronic Medical Record

## I have checked that on this Pull request

- [x] I can sucessfully create Drug orders
- [x] I can sucessfully create Lab orders
- [x] I can sucessfully search for drug orders
