### PR TITLE
OEUI-302: Tweak layout of "Add Order" button when restricting to a single order type

### DIFF
--- a/app/js/actions/createOrder.js
+++ b/app/js/actions/createOrder.js
@@ -3,10 +3,9 @@ import axiosInstance from '../config';
 
 import { SAVE_DRAFT_LAB_ORDER } from './actionTypes';
 
-const createOrder = (OrderData, returnUrl) => ({
+const createOrder = OrderData => ({
   type: SAVE_DRAFT_LAB_ORDER,
   payload: axiosInstance.post(`encounter`, OrderData),
-  meta: { returnUrl },
 });
 
 export default createOrder;

--- a/app/js/components/orderEntry/OrderEntryPage.jsx
+++ b/app/js/components/orderEntry/OrderEntryPage.jsx
@@ -48,21 +48,6 @@ export class OrderEntryPage extends PureComponent {
       errorMessage,
       labOrderData,
     } = this.props.createOrderReducer;
-    const {
-      orderables,
-    } = this.props.labOrderableReducer;
-    const { page } = this.state;
-    const {
-      labOrderableReducer,
-    } = prevProps;
-
-    if (labOrderableReducer.orderables[0].uuid !== orderables[0].uuid) {
-      if (page === 'laborders') {
-        this.props.setSelectedOrder({ currentOrderType: { id: 2, text: "Lab Orders" } });
-      } else if (page === 'drugorders') {
-        this.props.setSelectedOrder({ currentOrderType: { id: 1, text: "Drug Orders" } });
-      }
-    }
 
     if (added && labOrderData !== prevProps.createOrderReducer.labOrderData) {
       successToast('order successfully created');
@@ -160,7 +145,7 @@ export class OrderEntryPage extends PureComponent {
     urgency: order.urgency || 'ROUTINE',
   });
 
-  handleSubmit = (returnUrl) => {
+  handleSubmit = () => {
     const { draftLabOrders, draftDrugOrders } = this.props;
     const allDraftOrders = [...draftDrugOrders, ...draftLabOrders.orders];
     const orders = allDraftOrders.map(order =>
@@ -180,7 +165,7 @@ export class OrderEntryPage extends PureComponent {
       orders,
       patient: this.props.patient.uuid,
     };
-    this.props.createOrder(encounterPayload, returnUrl);
+    this.props.createOrder(encounterPayload);
   };
 
   renderDraftOrder = () => {
@@ -192,7 +177,7 @@ export class OrderEntryPage extends PureComponent {
         <Draft
           handleDraftDiscard={this.props.discardTestsInDraft}
           draftOrders={allDraftOrders}
-          handleSubmit={() => this.handleSubmit(returnUrl)}
+          handleSubmit={() => this.handleSubmit()}
           toggleDraftLabOrderUrgency={this.props.toggleDraftLabOrderUrgency}
           editDraftDrugOrder={this.props.editDraftDrugOrder}
         />
@@ -316,9 +301,10 @@ export class OrderEntryPage extends PureComponent {
                   <b>Orders List</b>
                 </h3>
               </div>
-              {!(page) && <SelectOrderType
+              {<SelectOrderType
                 switchOrderType={this.switchOrderType}
                 currentOrderType={this.props.currentOrderType}
+                page={page}
               />}
             </div>
             <div className="body-wrapper drug-order-entry">

--- a/app/js/components/orderEntry/SelectOrderType.jsx
+++ b/app/js/components/orderEntry/SelectOrderType.jsx
@@ -2,16 +2,29 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import * as orderTypes from './orderTypes';
 
-const SelectOrderType = ({ switchOrderType, currentOrderType }) => {
+const SelectOrderType = ({ switchOrderType, currentOrderType, page }) => {
   const orderTypesAsObject = Object.values(orderTypes);
+  let displayText = "Add Orders";
+  let clickHandler = () => {};
+  if (page === 'laborders') {
+    displayText = "Add Lab Orders";
+    clickHandler = () => switchOrderType(orderTypesAsObject[1]);
+  }
+
+  if (page === "drugorders") {
+    displayText = "Add Drug Orders";
+    clickHandler = () => switchOrderType(orderTypesAsObject[0]);
+  }
   return (
     <div className="dropdown">
       <div className="add-order-nav">
-        <button>
-          Add Order
+        <button
+          onClick={clickHandler}
+        >
+          {displayText}
         </button>
       </div>
-      <div className="dropdown-content">
+      <div className="dropdown-content" style={{ display: page && "none" }}>
         {orderTypesAsObject.map(orderType => (
           <div
             key={orderType.id}

--- a/app/js/components/orderEntry/SelectOrderType.jsx
+++ b/app/js/components/orderEntry/SelectOrderType.jsx
@@ -44,6 +44,7 @@ const SelectOrderType = ({ switchOrderType, currentOrderType, page }) => {
 SelectOrderType.propTypes = {
   currentOrderType: PropTypes.object.isRequired,
   switchOrderType: PropTypes.func.isRequired,
+  page: PropTypes.string.isRequired,
 };
 
 export default SelectOrderType;

--- a/app/js/middlewares/responseHandlerMiddleware.js
+++ b/app/js/middlewares/responseHandlerMiddleware.js
@@ -69,9 +69,6 @@ export default function responseHandlerMiddleware() {
       next({
         type: 'SET_SELECTED_ORDER', currentOrderType: {}, selectedorder: {}, activity: {},
       });
-      if (action.meta.returnUrl) {
-        window.location.href = action.meta.returnUrl;
-      }
     }
 
     if (action.payload) {


### PR DESCRIPTION
### **JIRA TICKET NAME**
[OEUI-302](https://issues.openmrs.org/browse/OEUI-302) Tweak layout of "Add Order" button when restricting to a single order type

### **Summary**
- Tweak layout of "Add Order" button when restricting to a single order type

## I have checked that on this Pull request

- [x] I can sucessfully create Drug orders
- [x] I can sucessfully create Lab orders
- [x] I can sucessfully search for drug orders
