### PR TITLE
UHM-3845: removed defaultPatient object in initialState

### DIFF
--- a/app/js/components/orderEntry/OrderEntryPage.jsx
+++ b/app/js/components/orderEntry/OrderEntryPage.jsx
@@ -284,7 +284,7 @@ export class OrderEntryPage extends PureComponent {
 
     return (
       <div className="order-entry-page">
-        {patientUuid ? (
+        {this.props.patient ? (
           <div>
             <PatientHeader
               patient={this.props.patient}
@@ -392,7 +392,6 @@ OrderEntryPage.propTypes = {
     }),
     currentLocation: PropTypes.object,
   }),
-  patient: PropTypes.shape({ uuid: PropTypes.string }),
   note: PropTypes.arrayOf(PropTypes.any).isRequired,
   getSettingEncounterType: PropTypes.func.isRequired,
   getSettingEncounterRole: PropTypes.func.isRequired,
@@ -413,6 +412,7 @@ OrderEntryPage.propTypes = {
     labOrderData: PropTypes.object,
   }).isRequired,
   fetchLabOrders: PropTypes.func.isRequired,
+  patient: PropTypes.shape({}),
 };
 
 OrderEntryPage.defaultProps = {
@@ -429,9 +429,7 @@ OrderEntryPage.defaultProps = {
   encounterRole: {
     uuid: '',
   },
-  patient: {
-    uuid: '',
-  },
+  patient: null,
   inpatientCareSetting: {
     uuid: '',
   },

--- a/app/js/reducers/initialState.js
+++ b/app/js/reducers/initialState.js
@@ -19,20 +19,6 @@ export default {
       display: '',
     },
   },
-  defaultPatient: {
-    patient: {
-      person: {
-        personName: {
-          givenName: '',
-          familyName: '',
-        },
-        preferredAddress: {},
-      },
-      patientIdentifier: {
-        identifier: '',
-      },
-    },
-  },
   defaultCareSetting: {
     outpatientCareSetting: null,
     inpatientCareSetting: null,

--- a/app/js/reducers/patientReducer.js
+++ b/app/js/reducers/patientReducer.js
@@ -1,7 +1,7 @@
 import { SET_PATIENT, SET_PATIENT_FAILED } from '../actions/actionTypes';
 import initialState from './initialState';
 
-export default (state = initialState.defaultPatient, action) => {
+export default (state = {}, action) => {
   switch (action.type) {
     case SET_PATIENT:
       return {

--- a/tests/components/orderentry/OrderEntryPage.test.jsx
+++ b/tests/components/orderentry/OrderEntryPage.test.jsx
@@ -91,7 +91,21 @@ describe('Test for Order entry page when orderentryowa.encounterType is set', ()
         orderables: [{
           uuid: '1234'
         }]
-      }
+      },
+      patient: {
+        patient: {
+          person: {
+            personName: {
+              givenName: '',
+              familyName: '',
+            },
+            preferredAddress: {},
+          },
+          patientIdentifier: {
+            identifier: '',
+          },
+        },
+      },
     };
     mountedComponent = undefined;
   });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -149,8 +149,6 @@ if (env === 'development') {
 }
 
 plugins.push(new BrowserSyncPlugin({
-	host: 'localhost',
-	port: 4000,
 	proxy: {
 		target: browserSyncTarget
 	}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -149,6 +149,8 @@ if (env === 'development') {
 }
 
 plugins.push(new BrowserSyncPlugin({
+	host: 'localhost',
+	port: 4000,
 	proxy: {
 		target: browserSyncTarget
 	}


### PR DESCRIPTION
### **Patient Header on Order Entry UI page does not display patient identifier**
[UHM-3845](https://tickets.pih-emr.org/browse/UHM-3845) Empty Strings in Patient Header

### **Summary**
- Fix for Patient Header on Order Entry UI page does not display patient identifier

## I have checked that on this Pull request

- [x] I can sucessfully create Drug orders
- [x] I can sucessfully create Lab orders
- [x] I can sucessfully search for drug orders
