### PR TITLE
Remove edit and cancel buttons from drug orders

### DIFF
--- a/app/js/components/orderEntry/OrderHeader.jsx
+++ b/app/js/components/orderEntry/OrderHeader.jsx
@@ -13,7 +13,7 @@ export const isCancellable = (order) => {
       !["IN_PROGRESS", "COMPLETED"].includes(order.fulfillerStatus));
     }
 
-export const isEditable = () => false;  // not working for drugs and not supported for labs
+export const isEditable = () => false; // not working for drugs and not supported for labs
 
 const OrderHeader = ({
   intl,

--- a/app/js/components/orderEntry/OrderHeader.jsx
+++ b/app/js/components/orderEntry/OrderHeader.jsx
@@ -8,13 +8,12 @@ import IconButton from '../button/IconButton';
 // export just for testing
 export const isCancellable = (order) => {
   const orderTypeName = order && order.orderType && order.orderType.name;
-  return orderTypeName === "Drug Order" ||
-  (orderTypeName === "Test Order" &&
+  return orderTypeName === "Test Order" &&
     (!order.fulfillerStatus ||
-      !["IN_PROGRESS", "COMPLETED"].includes(order.fulfillerStatus)));
+      !["IN_PROGRESS", "COMPLETED"].includes(order.fulfillerStatus));
     }
 
-export const isEditable = order => order && order.orderType && order.orderType.name === 'Drug Order';
+export const isEditable = () => false;  // not working for drugs and not supported for labs
 
 const OrderHeader = ({
   intl,

--- a/tests/components/orderentry/OrderHeader.test.jsx
+++ b/tests/components/orderentry/OrderHeader.test.jsx
@@ -30,7 +30,8 @@ describe('Component: OrderHeader', () => {
 
 describe('isEditable', () => {
 
-  it('isEditable should return true for drug orders', () => {
+  // TODO
+  xit('isEditable should return true for drug orders', () => {
 
     const order = {
       orderType: {
@@ -63,7 +64,8 @@ describe('isEditable', () => {
 
 describe('isCancellable', () => {
 
-  it('isCancellable should return true for drug orders', () => {
+  // TODO
+  xit('isCancellable should return true for drug orders', () => {
 
     const order = {
       orderType: {


### PR DESCRIPTION
The edit and cancel buttons didn't work out of the box for drug orders, and we're not going to fix them right now, so we're disabling them altogether for now.